### PR TITLE
Add site-wide CSP meta to cookie-policy.html (fixes #30)

### DIFF
--- a/cookie-policy.html
+++ b/cookie-policy.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta http-equiv="content-security-policy" content="default-src 'none'; font-src 'self' data:; img-src 'self' data:; style-src 'self' 'unsafe-inline'; media-src 'self' data:; script-src 'self' 'unsafe-inline' data:; object-src 'self' data:; frame-src 'self' data:;">
   <title>Cookie Policy | The Crooked House</title>
   <meta name="description" content="Cookie Policy for The Crooked House website">
   <link rel="canonical" href="https://thecrookedhouse.net/cookie-policy.html">


### PR DESCRIPTION
## Summary
Adds the same \`content-security-policy\` meta tag the four content pages use:

\`\`\`
default-src 'none'; font-src 'self' data:; img-src 'self' data:; style-src 'self' 'unsafe-inline'; media-src 'self' data:; script-src 'self' 'unsafe-inline' data:; object-src 'self' data:; frame-src 'self' data:;
\`\`\`

cookie-policy.html previously had no CSP, leaving it the only page with no script / style / image restriction.

## Verification
Loaded locally with the new CSP applied: \`cookie-consent.css\` still loads (verified \`document.styleSheets\` includes it) and \`cookie-consent-container\` still mounts, so the consent system continues to work on this page.

## Test plan
- [ ] Visit /cookie-policy.html in DevTools → Network → check no CSP-blocked requests
- [ ] Confirm "Back to Home" link still works
- [ ] Confirm cookie banner renders if consent isn't yet recorded