### PR TITLE
Add robots.txt and sitemap.xml (fixes #39)

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://thecrookedhouse.net/sitemap.xml

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://thecrookedhouse.net/</loc>
+    <changefreq>monthly</changefreq>
+    <priority>1.0</priority>
+  </url>
+  <url>
+    <loc>https://thecrookedhouse.net/donors/</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://thecrookedhouse.net/press/</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://thecrookedhouse.net/become-a-friend/</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://thecrookedhouse.net/cookie-policy.html</loc>
+    <changefreq>yearly</changefreq>
+    <priority>0.3</priority>
+  </url>
+</urlset>


### PR DESCRIPTION
## Summary
- \`robots.txt\` — \`User-agent: *\` allow-all + Sitemap reference
- \`sitemap.xml\` — five entries (/, /donors/, /press/, /become-a-friend/, /cookie-policy.html) with monthly changefreq

## Test plan
- [ ] \`curl https://thecrookedhouse.net/robots.txt\` → 200, plain text
- [ ] \`curl https://thecrookedhouse.net/sitemap.xml\` → 200, valid XML
- [ ] Submit sitemap to Google Search Console