### PR TITLE
Add custom 404 page (fixes #44)

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,0 +1,129 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta http-equiv="content-security-policy" content="default-src 'none'; font-src 'self' data:; img-src 'self' data:; style-src 'self' 'unsafe-inline'; media-src 'self' data:; script-src 'self' 'unsafe-inline' data:; object-src 'self' data:; frame-src 'self' data:;">
+  <title>Page Not Found | The Crooked House</title>
+  <meta name="description" content="The page you're looking for isn't here. Head back to The Crooked House home page.">
+  <link rel="stylesheet" href="/cookie-consent.css">
+  <style>
+    *,*::before,*::after{box-sizing:border-box;margin:0;padding:0}
+    html,body{height:100%}
+    body{
+      font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,'Helvetica Neue',Arial,sans-serif;
+      color:#222;
+      background:#fafafa;
+      display:flex;
+      flex-direction:column;
+      min-height:100vh;
+    }
+    header{
+      padding:24px 32px;
+      border-bottom:1px solid #eee;
+      background:#fff;
+    }
+    header a{
+      color:#222;
+      text-decoration:none;
+      font-size:20px;
+      font-weight:600;
+      letter-spacing:0.02em;
+    }
+    main{
+      flex:1;
+      display:flex;
+      align-items:center;
+      justify-content:center;
+      padding:48px 24px;
+    }
+    .card{
+      max-width:560px;
+      text-align:center;
+    }
+    .code{
+      font-size:84px;
+      font-weight:700;
+      color:#bbb;
+      line-height:1;
+      letter-spacing:-0.02em;
+      margin-bottom:16px;
+    }
+    h1{
+      font-size:32px;
+      font-weight:700;
+      margin-bottom:16px;
+      color:#222;
+    }
+    p{
+      font-size:17px;
+      color:#555;
+      line-height:1.55;
+      margin-bottom:32px;
+    }
+    .links{
+      display:flex;
+      flex-wrap:wrap;
+      gap:12px;
+      justify-content:center;
+    }
+    .links a{
+      display:inline-block;
+      padding:12px 24px;
+      border-radius:999px;
+      background:#000;
+      color:#fff;
+      text-decoration:none;
+      font-size:14px;
+      font-weight:600;
+      letter-spacing:0.06em;
+      text-transform:uppercase;
+    }
+    .links a.secondary{
+      background:#fff;
+      color:#222;
+      border:1px solid #ccc;
+    }
+    .links a:hover{
+      opacity:0.85;
+    }
+    footer{
+      padding:24px;
+      text-align:center;
+      font-size:13px;
+      color:#888;
+    }
+    @media (max-width:480px){
+      header{padding:16px 20px}
+      .code{font-size:64px}
+      h1{font-size:24px}
+      p{font-size:15px}
+      .links a{padding:10px 18px;font-size:12px}
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <a href="/">The Crooked House</a>
+  </header>
+  <main>
+    <div class="card">
+      <div class="code">404</div>
+      <h1>This page wandered off</h1>
+      <p>The page you were looking for isn't here. It may have moved, or the link that brought you here might be off by a letter or two. Here's where to find what you need:</p>
+      <div class="links">
+        <a href="/">Home</a>
+        <a href="https://www.paypal.com/donate/?hosted_button_id=X4VGJ5VTWXVUN" class="secondary">Donate</a>
+        <a href="/donors/" class="secondary">Donors</a>
+        <a href="/become-a-friend/" class="secondary">Become a Friend</a>
+        <a href="/press/" class="secondary">Press</a>
+      </div>
+    </div>
+  </main>
+  <footer>
+    The Crooked House at Homecoming Park &mdash; a sculpture by Benjamin Fehl
+  </footer>
+  <script src="/cookie-consent.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
Adds \`404.html\` at the repo root so GitHub Pages serves it for unmatched routes instead of the generic "Unicorn" page.

The page:
- Renders branded "The Crooked House" header at top
- Big "404" + friendly message: "This page wandered off"
- 5 link buttons: Home / Donate / Donors / Become a Friend / Press
- Loads \`/cookie-consent.css\` and \`/cookie-consent.js\` so the consent UI still works
- Same CSP meta as the rest of the site
- Mobile-responsive (≤480px gets tighter padding and smaller font)

## Test plan
- [ ] After deploy, visit https://thecrookedhouse.net/this-does-not-exist
- [ ] Branded 404 renders (not the GitHub Unicorn)
- [ ] HTTP status is still 404 (\`curl -I\`)
- [ ] All 5 link buttons work
- [ ] Cookie banner shows if consent not yet recorded