### PR TITLE
Follow-up: fix unquoted alt=filename in gallery imgs

### DIFF
--- a/index.html
+++ b/index.html
@@ -510,7 +510,7 @@
  
  <div class=Parallax-item data-parallax-item data-parallax-id=57c4f6ddf7e0ab9190e16ea1 style=top:140px;left:0px;width:1710px;height:1918px;transform:translate3d(0px,0px,0px)><figure class="Index-page-image loaded" data-parallax-image-wrapper style=top:-300px;overflow:hidden;transform:translate3d(0px,-34.7208px,0px)>
  
- <img data-src=https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1476053647950-VD31WVZ1TG85YPFWY6P7/banner4-02.jpg data-image=https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1476053647950-VD31WVZ1TG85YPFWY6P7/banner4-02.jpg data-image-dimensions=738x400 data-image-focal-point=0.5,0.5 data-load=false data-parent-ratio=0.8 alt=banner4-02.jpg data-image-resolution=2500w src="images/inline/inline-5fbae4f2c5.webp" style=font-size:0px;left:-1191.11px;top:0px;width:4092.21px;height:2218px;position:relative>
+ <img data-src=https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1476053647950-VD31WVZ1TG85YPFWY6P7/banner4-02.jpg data-image=https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1476053647950-VD31WVZ1TG85YPFWY6P7/banner4-02.jpg data-image-dimensions=738x400 data-image-focal-point=0.5,0.5 data-load=false data-parent-ratio=0.8 alt="" data-image-resolution=2500w src="images/inline/inline-5fbae4f2c5.webp" style=font-size:0px;left:-1191.11px;top:0px;width:4092.21px;height:2218px;position:relative>
  </figure></div>
  
  
@@ -520,7 +520,7 @@
  
  <div class=Parallax-item data-parallax-item data-parallax-id=57e9d02ce58c62718a9fa402 style=top:2056px;left:0px;width:1710px;height:724px;transform:translate3d(-1710px,0px,0px)><figure class="Index-page-image loaded" data-parallax-image-wrapper style=top:-300px;overflow:hidden>
  
- <img data-src=https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1474941829634-QEII8P8G3AFUBDKJJVQL/blue-bg.jpg data-image=https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1474941829634-QEII8P8G3AFUBDKJJVQL/blue-bg.jpg data-image-dimensions=1600x400 data-image-focal-point=0.6848739495798319,0.47478991596638653 data-load=false data-parent-ratio=1.7 alt=blue-bg.jpg data-image-resolution=2500w src=images/inline/inline-aed3178dcf.webp style=font-size:0px;left:-1950.24px;top:0px;width:4096px;height:1024px;position:relative>
+ <img data-src=https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1474941829634-QEII8P8G3AFUBDKJJVQL/blue-bg.jpg data-image=https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1474941829634-QEII8P8G3AFUBDKJJVQL/blue-bg.jpg data-image-dimensions=1600x400 data-image-focal-point=0.6848739495798319,0.47478991596638653 data-load=false data-parent-ratio=1.7 alt="" data-image-resolution=2500w src=images/inline/inline-aed3178dcf.webp style=font-size:0px;left:-1950.24px;top:0px;width:4096px;height:1024px;position:relative>
  </figure></div>
  
  
@@ -535,7 +535,7 @@
  
  <div class=Parallax-item data-parallax-item data-parallax-id=57c507a86b8f5b269969d361 style=top:3681px;left:0px;width:1710px;height:740px;transform:translate3d(-1710px,0px,0px)><figure class="Index-page-image loaded" data-parallax-image-wrapper style=top:-300px;overflow:hidden>
  
- <img data-src=https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1472909992334-URHU4KRB3JD3RUEF0PBG/essence-bg-02.jpg data-image=https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1472909992334-URHU4KRB3JD3RUEF0PBG/essence-bg-02.jpg data-image-dimensions=1600x1066 data-image-focal-point=0.5,0.5 data-load=false data-parent-ratio=1.6 alt=essence-bg-02.jpg data-image-resolution=2500w src=images/inline/inline-e4e4e6202e.webp style=font-size:0px;left:-1.13687e-13px;top:-49.6437px;width:1710px;height:1139.29px;position:relative>
+ <img data-src=https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1472909992334-URHU4KRB3JD3RUEF0PBG/essence-bg-02.jpg data-image=https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1472909992334-URHU4KRB3JD3RUEF0PBG/essence-bg-02.jpg data-image-dimensions=1600x1066 data-image-focal-point=0.5,0.5 data-load=false data-parent-ratio=1.6 alt="" data-image-resolution=2500w src=images/inline/inline-e4e4e6202e.webp style=font-size:0px;left:-1.13687e-13px;top:-49.6437px;width:1710px;height:1139.29px;position:relative>
  </figure></div>
  
  
@@ -550,7 +550,7 @@
  
  <div class=Parallax-item data-parallax-item data-parallax-id=57c4fb58440243c93126d4e3 style=top:5956px;left:0px;width:1710px;height:196px;transform:translate3d(-1710px,0px,0px)><figure class="Index-page-image loaded" data-parallax-image-wrapper style=top:-300px;overflow:hidden>
  
- <img data-src=https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1472527581872-IMJ5OG56YEBM6UUSMPKT/20150502_131124_IMG_9411.jpg data-image=https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1472527581872-IMJ5OG56YEBM6UUSMPKT/20150502_131124_IMG_9411.jpg data-image-dimensions=1600x1067 data-image-focal-point=0.5,0.5 data-load=false data-parent-ratio=3.4 alt=20150502_131124_IMG_9411.jpg data-image-resolution=2500w src="images/inline/inline-c37e00215d.webp" style=font-size:0px;left:-1.13687e-13px;top:-322.178px;width:1710px;height:1140.36px;position:relative>
+ <img data-src=https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1472527581872-IMJ5OG56YEBM6UUSMPKT/20150502_131124_IMG_9411.jpg data-image=https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1472527581872-IMJ5OG56YEBM6UUSMPKT/20150502_131124_IMG_9411.jpg data-image-dimensions=1600x1067 data-image-focal-point=0.5,0.5 data-load=false data-parent-ratio=3.4 alt="The Crooked House sculpture during construction" data-image-resolution=2500w src="images/inline/inline-c37e00215d.webp" style=font-size:0px;left:-1.13687e-13px;top:-322.178px;width:1710px;height:1140.36px;position:relative>
  </figure></div>
  
  
@@ -689,7 +689,7 @@
  
  <span class=v6-visually-hidden>View fullsize</span>
  
- <noscript><img src="https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1472907442941-POGDKFY4AF43XGOT9KBV/13613563_10153834490481915_668322719579670_o.jpg" alt="The Crooked House sculpture"></noscript><img class="thumb-image loaded" elementtiming=system-gallery-block-grid data-src=https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1472907442941-POGDKFY4AF43XGOT9KBV/13613563_10153834490481915_668322719579670_o.jpg data-image=https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1472907442941-POGDKFY4AF43XGOT9KBV/13613563_10153834490481915_668322719579670_o.jpg data-image-dimensions=1024x768 data-image-focal-point=0.5,0.5 data-load=false data-image-id=57cac8b2bebafb5698fe38f1 data-type=image style=left:-21.8333px;top:0px;width:174.667px;height:131px;position:relative data-parent-ratio=1.0 alt=13613563_10153834490481915_668322719579670_o.jpg data-image-resolution=500w src=images/inline/inline-7df76ef290.webp>
+ <noscript><img src="https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1472907442941-POGDKFY4AF43XGOT9KBV/13613563_10153834490481915_668322719579670_o.jpg" alt="The Crooked House sculpture"></noscript><img class="thumb-image loaded" elementtiming=system-gallery-block-grid data-src=https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1472907442941-POGDKFY4AF43XGOT9KBV/13613563_10153834490481915_668322719579670_o.jpg data-image=https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1472907442941-POGDKFY4AF43XGOT9KBV/13613563_10153834490481915_668322719579670_o.jpg data-image-dimensions=1024x768 data-image-focal-point=0.5,0.5 data-load=false data-image-id=57cac8b2bebafb5698fe38f1 data-type=image style=left:-21.8333px;top:0px;width:174.667px;height:131px;position:relative data-parent-ratio=1.0 alt="The Crooked House sculpture" data-image-resolution=500w src=images/inline/inline-7df76ef290.webp>
  </a>
  
  </div>
@@ -729,7 +729,7 @@
  
  <span class=v6-visually-hidden>View fullsize</span>
  
- <noscript><img src="https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1472907503309-798WCPDVYHRCKM5TJIJS/IMG_8129.jpg" alt="The Crooked House sculpture"></noscript><img class="thumb-image loaded" elementtiming=system-gallery-block-grid data-src=https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1472907503309-798WCPDVYHRCKM5TJIJS/IMG_8129.jpg data-image=https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1472907503309-798WCPDVYHRCKM5TJIJS/IMG_8129.jpg data-image-dimensions=2500x1803 data-image-focal-point=0.5,0.5 data-load=false data-image-id=57cac8ea1b631bb8d8d7cac4 data-type=image style=left:-25.3209px;top:0px;width:181.642px;height:131px;position:relative data-parent-ratio=1.0 alt=IMG_8129.jpg data-image-resolution=500w src="images/inline/inline-162cdd6398.webp">
+ <noscript><img src="https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1472907503309-798WCPDVYHRCKM5TJIJS/IMG_8129.jpg" alt="The Crooked House sculpture"></noscript><img class="thumb-image loaded" elementtiming=system-gallery-block-grid data-src=https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1472907503309-798WCPDVYHRCKM5TJIJS/IMG_8129.jpg data-image=https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1472907503309-798WCPDVYHRCKM5TJIJS/IMG_8129.jpg data-image-dimensions=2500x1803 data-image-focal-point=0.5,0.5 data-load=false data-image-id=57cac8ea1b631bb8d8d7cac4 data-type=image style=left:-25.3209px;top:0px;width:181.642px;height:131px;position:relative data-parent-ratio=1.0 alt="The Crooked House sculpture" data-image-resolution=500w src="images/inline/inline-162cdd6398.webp">
  </a>
  
  </div>
@@ -749,7 +749,7 @@
  
  <span class=v6-visually-hidden>View fullsize</span>
  
- <noscript><img src="https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1474942733064-728ECX7KJ990FH6ATCV5/14358696_1775874472686073_5247345269486102013_n-1.jpg" alt="The Crooked House sculpture"></noscript><img class="thumb-image loaded" elementtiming=system-gallery-block-grid data-src=https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1474942733064-728ECX7KJ990FH6ATCV5/14358696_1775874472686073_5247345269486102013_n-1.jpg data-image=https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1474942733064-728ECX7KJ990FH6ATCV5/14358696_1775874472686073_5247345269486102013_n-1.jpg data-image-dimensions=792x594 data-image-focal-point=0.5,0.5 data-load=false data-image-id=57e9d70cb3db2be1c7d76c3a data-type=image style=left:-21.8333px;top:0px;width:174.667px;height:131px;position:relative data-parent-ratio=1.0 alt=14358696_1775874472686073_5247345269486102013_n-1.jpg data-image-resolution=500w src=images/inline/inline-6ac0338f55.webp>
+ <noscript><img src="https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1474942733064-728ECX7KJ990FH6ATCV5/14358696_1775874472686073_5247345269486102013_n-1.jpg" alt="The Crooked House sculpture"></noscript><img class="thumb-image loaded" elementtiming=system-gallery-block-grid data-src=https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1474942733064-728ECX7KJ990FH6ATCV5/14358696_1775874472686073_5247345269486102013_n-1.jpg data-image=https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1474942733064-728ECX7KJ990FH6ATCV5/14358696_1775874472686073_5247345269486102013_n-1.jpg data-image-dimensions=792x594 data-image-focal-point=0.5,0.5 data-load=false data-image-id=57e9d70cb3db2be1c7d76c3a data-type=image style=left:-21.8333px;top:0px;width:174.667px;height:131px;position:relative data-parent-ratio=1.0 alt="The Crooked House sculpture" data-image-resolution=500w src=images/inline/inline-6ac0338f55.webp>
  </a>
  
  </div>
@@ -769,7 +769,7 @@
  
  <span class=v6-visually-hidden>View fullsize</span>
  
- <noscript><img src="https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1729488868033-HDRRNCFRAWB0JEG4YCIV/IMG_2876.jpeg" alt="The Crooked House sculpture"></noscript><img class="thumb-image loaded" elementtiming=system-gallery-block-grid data-src=https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1729488868033-HDRRNCFRAWB0JEG4YCIV/IMG_2876.jpeg data-image=https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1729488868033-HDRRNCFRAWB0JEG4YCIV/IMG_2876.jpeg data-image-dimensions=4032x3024 data-image-focal-point=0.5,0.5 data-load=false data-image-id=6715e7e273121e339c3b3e43 data-type=image style=left:-21.8333px;top:0px;width:174.667px;height:131px;position:relative data-parent-ratio=1.0 alt=IMG_2876.jpeg data-image-resolution=500w src=images/inline/inline-e7642f0df5.webp>
+ <noscript><img src="https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1729488868033-HDRRNCFRAWB0JEG4YCIV/IMG_2876.jpeg" alt="The Crooked House sculpture"></noscript><img class="thumb-image loaded" elementtiming=system-gallery-block-grid data-src=https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1729488868033-HDRRNCFRAWB0JEG4YCIV/IMG_2876.jpeg data-image=https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1729488868033-HDRRNCFRAWB0JEG4YCIV/IMG_2876.jpeg data-image-dimensions=4032x3024 data-image-focal-point=0.5,0.5 data-load=false data-image-id=6715e7e273121e339c3b3e43 data-type=image style=left:-21.8333px;top:0px;width:174.667px;height:131px;position:relative data-parent-ratio=1.0 alt="The Crooked House sculpture" data-image-resolution=500w src=images/inline/inline-e7642f0df5.webp>
  </a>
  
  </div>
@@ -809,7 +809,7 @@
  
  <span class=v6-visually-hidden>View fullsize</span>
  
- <noscript><img src="https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1729489111968-L8PAEF952W83Y0XD4ZR5/IMG_9658.jpg" alt="The Crooked House sculpture"></noscript><img class="thumb-image loaded" elementtiming=system-gallery-block-grid data-src=https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1729489111968-L8PAEF952W83Y0XD4ZR5/IMG_9658.jpg data-image=https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1729489111968-L8PAEF952W83Y0XD4ZR5/IMG_9658.jpg data-image-dimensions=2448x3264 data-image-focal-point=0.5,0.5 data-load=false data-image-id=6715e8d6da31b53ff6d08923 data-type=image style=left:0px;top:-21.8333px;width:131px;height:174.667px;position:relative data-parent-ratio=1.0 alt=IMG_9658.jpg data-image-resolution=300w src="images/inline/inline-a9bc959431.webp">
+ <noscript><img src="https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1729489111968-L8PAEF952W83Y0XD4ZR5/IMG_9658.jpg" alt="The Crooked House sculpture"></noscript><img class="thumb-image loaded" elementtiming=system-gallery-block-grid data-src=https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1729489111968-L8PAEF952W83Y0XD4ZR5/IMG_9658.jpg data-image=https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1729489111968-L8PAEF952W83Y0XD4ZR5/IMG_9658.jpg data-image-dimensions=2448x3264 data-image-focal-point=0.5,0.5 data-load=false data-image-id=6715e8d6da31b53ff6d08923 data-type=image style=left:0px;top:-21.8333px;width:131px;height:174.667px;position:relative data-parent-ratio=1.0 alt="The Crooked House sculpture" data-image-resolution=300w src="images/inline/inline-a9bc959431.webp">
  </a>
  
  </div>
@@ -829,7 +829,7 @@
  
  <span class=v6-visually-hidden>View fullsize</span>
  
- <noscript><img src="https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1729489302851-CBGSHWMD10CLRK9FMYNK/IMG_8093.jpg" alt="The Crooked House sculpture"></noscript><img class="thumb-image loaded" elementtiming=system-gallery-block-grid data-src=https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1729489302851-CBGSHWMD10CLRK9FMYNK/IMG_8093.jpg data-image=https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1729489302851-CBGSHWMD10CLRK9FMYNK/IMG_8093.jpg data-image-dimensions=2448x3264 data-image-focal-point=0.5,0.5 data-load=false data-image-id=6715e996562d330726e88397 data-type=image style=left:0px;top:-21.8333px;width:131px;height:174.667px;position:relative data-parent-ratio=1.0 alt=IMG_8093.jpg data-image-resolution=300w src="images/inline/inline-59b243ff7e.webp">
+ <noscript><img src="https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1729489302851-CBGSHWMD10CLRK9FMYNK/IMG_8093.jpg" alt="The Crooked House sculpture"></noscript><img class="thumb-image loaded" elementtiming=system-gallery-block-grid data-src=https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1729489302851-CBGSHWMD10CLRK9FMYNK/IMG_8093.jpg data-image=https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1729489302851-CBGSHWMD10CLRK9FMYNK/IMG_8093.jpg data-image-dimensions=2448x3264 data-image-focal-point=0.5,0.5 data-load=false data-image-id=6715e996562d330726e88397 data-type=image style=left:0px;top:-21.8333px;width:131px;height:174.667px;position:relative data-parent-ratio=1.0 alt="The Crooked House sculpture" data-image-resolution=300w src="images/inline/inline-59b243ff7e.webp">
  </a>
  
  </div>
@@ -849,7 +849,7 @@
  
  <span class=v6-visually-hidden>View fullsize</span>
  
- <noscript><img src="https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1729489319403-KBLDN3G1HO404PKD5NAJ/IMG_1863.jpeg" alt="The Crooked House facade"></noscript><img class="thumb-image loaded" elementtiming=system-gallery-block-grid data-src=https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1729489319403-KBLDN3G1HO404PKD5NAJ/IMG_1863.jpeg data-image=https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1729489319403-KBLDN3G1HO404PKD5NAJ/IMG_1863.jpeg data-image-dimensions=4032x3024 data-image-focal-point=0.5,0.5 data-load=false data-image-id=6715e9a50133582a7a1577ce data-type=image style=left:-21.8333px;top:0px;width:174.667px;height:131px;position:relative data-parent-ratio=1.0 alt=IMG_1863.jpeg data-image-resolution=500w src="images/inline/inline-92b408ebae.webp">
+ <noscript><img src="https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1729489319403-KBLDN3G1HO404PKD5NAJ/IMG_1863.jpeg" alt="The Crooked House facade"></noscript><img class="thumb-image loaded" elementtiming=system-gallery-block-grid data-src=https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1729489319403-KBLDN3G1HO404PKD5NAJ/IMG_1863.jpeg data-image=https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1729489319403-KBLDN3G1HO404PKD5NAJ/IMG_1863.jpeg data-image-dimensions=4032x3024 data-image-focal-point=0.5,0.5 data-load=false data-image-id=6715e9a50133582a7a1577ce data-type=image style=left:-21.8333px;top:0px;width:174.667px;height:131px;position:relative data-parent-ratio=1.0 alt="The Crooked House facade" data-image-resolution=500w src="images/inline/inline-92b408ebae.webp">
  </a>
  
  </div>
@@ -909,7 +909,7 @@
  
  <span class=v6-visually-hidden>View fullsize</span>
  
- <noscript><img src="https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1729489633016-F6DIR7Z5JA2P8E8DTEVH/IMG_5668.jpg" alt="The Crooked House sculpture"></noscript><img class="thumb-image loaded" elementtiming=system-gallery-block-grid data-src=https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1729489633016-F6DIR7Z5JA2P8E8DTEVH/IMG_5668.jpg data-image=https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1729489633016-F6DIR7Z5JA2P8E8DTEVH/IMG_5668.jpg data-image-dimensions=2448x3264 data-image-focal-point=0.5,0.5 data-load=false data-image-id=6715eadfd4b2a0310c727a31 data-type=image style=left:0px;top:-21.8333px;width:131px;height:174.667px;position:relative data-parent-ratio=1.0 alt=IMG_5668.jpg data-image-resolution=300w src="images/inline/inline-45fe7f473a.webp">
+ <noscript><img src="https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1729489633016-F6DIR7Z5JA2P8E8DTEVH/IMG_5668.jpg" alt="The Crooked House sculpture"></noscript><img class="thumb-image loaded" elementtiming=system-gallery-block-grid data-src=https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1729489633016-F6DIR7Z5JA2P8E8DTEVH/IMG_5668.jpg data-image=https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1729489633016-F6DIR7Z5JA2P8E8DTEVH/IMG_5668.jpg data-image-dimensions=2448x3264 data-image-focal-point=0.5,0.5 data-load=false data-image-id=6715eadfd4b2a0310c727a31 data-type=image style=left:0px;top:-21.8333px;width:131px;height:174.667px;position:relative data-parent-ratio=1.0 alt="The Crooked House sculpture" data-image-resolution=300w src="images/inline/inline-45fe7f473a.webp">
  </a>
  
  </div>
@@ -929,7 +929,7 @@
  
  <span class=v6-visually-hidden>View fullsize</span>
  
- <noscript><img src="https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1729489769419-T1Q1WDKIP8ZLNIDGLCZQ/IMG_0911.jpg" alt="The Crooked House sculpture"></noscript><img class="thumb-image loaded" elementtiming=system-gallery-block-grid data-src=https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1729489769419-T1Q1WDKIP8ZLNIDGLCZQ/IMG_0911.jpg data-image=https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1729489769419-T1Q1WDKIP8ZLNIDGLCZQ/IMG_0911.jpg data-image-dimensions=2679x3185 data-image-focal-point=0.5,0.5 data-load=false data-image-id=6715eb68cb7cd82c37665c18 data-type=image style=left:0px;top:-12.3714px;width:131px;height:155.743px;position:relative data-parent-ratio=1.0 alt=IMG_0911.jpg data-image-resolution=300w src="images/inline/inline-35b1c1af25.webp">
+ <noscript><img src="https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1729489769419-T1Q1WDKIP8ZLNIDGLCZQ/IMG_0911.jpg" alt="The Crooked House sculpture"></noscript><img class="thumb-image loaded" elementtiming=system-gallery-block-grid data-src=https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1729489769419-T1Q1WDKIP8ZLNIDGLCZQ/IMG_0911.jpg data-image=https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1729489769419-T1Q1WDKIP8ZLNIDGLCZQ/IMG_0911.jpg data-image-dimensions=2679x3185 data-image-focal-point=0.5,0.5 data-load=false data-image-id=6715eb68cb7cd82c37665c18 data-type=image style=left:0px;top:-12.3714px;width:131px;height:155.743px;position:relative data-parent-ratio=1.0 alt="The Crooked House sculpture" data-image-resolution=300w src="images/inline/inline-35b1c1af25.webp">
  </a>
  
  </div>
@@ -949,7 +949,7 @@
  
  <span class=v6-visually-hidden>View fullsize</span>
  
- <noscript><img src="https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1729490139216-CRGKY4WPT953IK948PFP/IMG_1672.jpeg" alt="The Crooked House sculpture"></noscript><img class="thumb-image loaded" elementtiming=system-gallery-block-grid data-src=https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1729490139216-CRGKY4WPT953IK948PFP/IMG_1672.jpeg data-image=https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1729490139216-CRGKY4WPT953IK948PFP/IMG_1672.jpeg data-image-dimensions=3024x4032 data-image-focal-point=0.5,0.5 data-load=false data-image-id=6715ecd88692445dd1039746 data-type=image style=left:0px;top:-21.8333px;width:131px;height:174.667px;position:relative data-parent-ratio=1.0 alt=IMG_1672.jpeg data-image-resolution=300w src="images/inline/inline-adec42c0c9.webp">
+ <noscript><img src="https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1729490139216-CRGKY4WPT953IK948PFP/IMG_1672.jpeg" alt="The Crooked House sculpture"></noscript><img class="thumb-image loaded" elementtiming=system-gallery-block-grid data-src=https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1729490139216-CRGKY4WPT953IK948PFP/IMG_1672.jpeg data-image=https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1729490139216-CRGKY4WPT953IK948PFP/IMG_1672.jpeg data-image-dimensions=3024x4032 data-image-focal-point=0.5,0.5 data-load=false data-image-id=6715ecd88692445dd1039746 data-type=image style=left:0px;top:-21.8333px;width:131px;height:174.667px;position:relative data-parent-ratio=1.0 alt="The Crooked House sculpture" data-image-resolution=300w src="images/inline/inline-adec42c0c9.webp">
  </a>
  
  </div>
@@ -969,7 +969,7 @@
  
  <span class=v6-visually-hidden>View fullsize</span>
  
- <noscript><img src="https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1729490047506-LWUOLGW6YZVPH1MXJYSN/IMG_0232.jpeg" alt="The Crooked House sculpture"></noscript><img class="thumb-image loaded" elementtiming=system-gallery-block-grid data-src=https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1729490047506-LWUOLGW6YZVPH1MXJYSN/IMG_0232.jpeg data-image=https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1729490047506-LWUOLGW6YZVPH1MXJYSN/IMG_0232.jpeg data-image-dimensions=4032x3024 data-image-focal-point=0.5,0.5 data-load=false data-image-id=6715ec7c7fe32942f5e2c9aa data-type=image style=left:-21.8333px;top:0px;width:174.667px;height:131px;position:relative data-parent-ratio=1.0 alt=IMG_0232.jpeg data-image-resolution=500w src=images/inline/inline-91eda3ff24.webp>
+ <noscript><img src="https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1729490047506-LWUOLGW6YZVPH1MXJYSN/IMG_0232.jpeg" alt="The Crooked House sculpture"></noscript><img class="thumb-image loaded" elementtiming=system-gallery-block-grid data-src=https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1729490047506-LWUOLGW6YZVPH1MXJYSN/IMG_0232.jpeg data-image=https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1729490047506-LWUOLGW6YZVPH1MXJYSN/IMG_0232.jpeg data-image-dimensions=4032x3024 data-image-focal-point=0.5,0.5 data-load=false data-image-id=6715ec7c7fe32942f5e2c9aa data-type=image style=left:-21.8333px;top:0px;width:174.667px;height:131px;position:relative data-parent-ratio=1.0 alt="The Crooked House sculpture" data-image-resolution=500w src=images/inline/inline-91eda3ff24.webp>
  </a>
  
  </div>
@@ -989,7 +989,7 @@
  
  <span class=v6-visually-hidden>View fullsize</span>
  
- <noscript><img src="https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1729490190942-U58FIJ5GE3MHZ6WSMBUU/IMG_9121.jpeg" alt="The Crooked House sculpture"></noscript><img class="thumb-image loaded" elementtiming=system-gallery-block-grid data-src=https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1729490190942-U58FIJ5GE3MHZ6WSMBUU/IMG_9121.jpeg data-image=https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1729490190942-U58FIJ5GE3MHZ6WSMBUU/IMG_9121.jpeg data-image-dimensions=3264x2448 data-image-focal-point=0.5,0.5 data-load=false data-image-id=6715ed0d55c3b24d2ac63e75 data-type=image style=left:-21.8333px;top:0px;width:174.667px;height:131px;position:relative data-parent-ratio=1.0 alt=IMG_9121.jpeg data-image-resolution=500w src="images/inline/inline-7cee3944c6.webp">
+ <noscript><img src="https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1729490190942-U58FIJ5GE3MHZ6WSMBUU/IMG_9121.jpeg" alt="The Crooked House sculpture"></noscript><img class="thumb-image loaded" elementtiming=system-gallery-block-grid data-src=https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1729490190942-U58FIJ5GE3MHZ6WSMBUU/IMG_9121.jpeg data-image=https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1729490190942-U58FIJ5GE3MHZ6WSMBUU/IMG_9121.jpeg data-image-dimensions=3264x2448 data-image-focal-point=0.5,0.5 data-load=false data-image-id=6715ed0d55c3b24d2ac63e75 data-type=image style=left:-21.8333px;top:0px;width:174.667px;height:131px;position:relative data-parent-ratio=1.0 alt="The Crooked House sculpture" data-image-resolution=500w src="images/inline/inline-7cee3944c6.webp">
  </a>
  
  </div>


### PR DESCRIPTION
## Summary
PR #49 fixed all \`alt="..."\` quoted forms on the home page, but missed the **unquoted** form \`alt=filename.jpg\` that the Squarespace gallery uses for its JS-loaded thumbnail \`<img>\` elements (siblings of the \`<noscript>\` fallbacks).

Final 16 instances cleaned up:
- 3 decorative backgrounds set to \`alt=""\`
- 13 gallery photos get descriptive alt ("The Crooked House sculpture", "The Crooked House facade", etc.)
- Now zero filename-extension alt attributes remain on the page

## Test plan
- [ ] \`curl https://thecrookedhouse.net/ | grep -E 'alt=[A-Za-z0-9._-]+\.(jpg|jpeg|png|gif|webp)'\` returns nothing
- [ ] axe-core / Lighthouse: alt-text rule passes