### PR TITLE
Add H1 + fix alt text on donors and BaF

### DIFF
--- a/become-a-friend/index.html
+++ b/become-a-friend/index.html
@@ -85,7 +85,7 @@
  <section class=Main-content data-content-field=main-content>
  <div class="sqs-layout sqs-grid-12 columns-12" data-type=page data-updated-on=1729646691487 id=page-57c50546725e25ba4eb7214b><div class="row sqs-row"><div class="col sqs-col-8 span-8"><div class="sqs-block html-block sqs-block-html" data-block-type=2 data-sqsp-block=text id=block-dfa22cb243f7f68660b2><div class=sqs-block-content>
 <div class=sqs-html-content data-sqsp-text-block-content>
- <h3 style=white-space:pre-wrap>become A friend of</h3><h2 style=white-space:pre-wrap><strong>the Crooked House</strong></h2>
+ <h3 style=white-space:pre-wrap>become A friend of</h3><h1 style=white-space:pre-wrap><strong>the Crooked House</strong></h1>
 </div>
  
  

--- a/donors/index.html
+++ b/donors/index.html
@@ -52,7 +52,7 @@
  
  <div class=Parallax-item data-parallax-item data-parallax-id=57df0fc4197aea80c360393f style=top:0px;left:0px;width:1710px;height:183px;transform:translate3d(0px,0px,0px)><figure class="Intro-image loaded" data-parallax-image-wrapper style=top:-300px;overflow:hidden;transform:translate3d(0px,258.755px,0px)>
  
- <img data-src=https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1474242119990-358VE343NI7Y0AW9IHLM/IMG_1567.jpg data-image=https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1474242119990-358VE343NI7Y0AW9IHLM/IMG_1567.jpg data-image-dimensions=1653x612 data-image-focal-point=0.54,0.74 data-load=false data-parent-ratio=3.5 alt=IMG_1567.jpg data-image-resolution=2500w src="../images/inline/inline-15b356cd85.webp" style=font-size:0px;left:-2.27374e-13px;top:-150.103px;width:1710px;height:633.103px;position:relative>
+ <img data-src=https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1474242119990-358VE343NI7Y0AW9IHLM/IMG_1567.jpg data-image=https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1474242119990-358VE343NI7Y0AW9IHLM/IMG_1567.jpg data-image-dimensions=1653x612 data-image-focal-point=0.54,0.74 data-load=false data-parent-ratio=3.5 alt="Donors thank-you image" data-image-resolution=2500w src="../images/inline/inline-15b356cd85.webp" style=font-size:0px;left:-2.27374e-13px;top:-150.103px;width:1710px;height:633.103px;position:relative>
  </figure></div>
  
  
@@ -119,7 +119,7 @@
  <section class=Main-content data-content-field=main-content>
  <div class="sqs-layout sqs-grid-12 columns-12" data-type=page data-updated-on=1577576146518 id=page-57df0fc4197aea80c360393f><div class="row sqs-row"><div class="col sqs-col-12 span-12"><div class="sqs-block html-block sqs-block-html" data-block-type=2 data-sqsp-block=text id=block-yui_3_17_2_3_1474236283063_14686><div class=sqs-block-content>
 <div class=sqs-html-content data-sqsp-text-block-content>
- <h2 style=text-align:center;white-space:pre-wrap><strong>The Crooked House at Homecoming Park Donors</strong></h2><p style=text-align:center;white-space:pre-wrap><strong><em>We are immensely grateful to all the individuals, businesses, and grantmakers who make The Crooked House Project possible through their ongoing financial support.</em></strong></p>
+ <h1 style=text-align:center;white-space:pre-wrap><strong>The Crooked House at Homecoming Park Donors</strong></h1><p style=text-align:center;white-space:pre-wrap><strong><em>We are immensely grateful to all the individuals, businesses, and grantmakers who make The Crooked House Project possible through their ongoing financial support.</em></strong></p>
 </div>
 </div></div>
 


### PR DESCRIPTION
## Summary
PR #50 fixed the home page heading hierarchy; PRs #49+#53 fixed home-page alt text. Two follow-ups on the other content pages:

**/donors/** — had **zero H1 tags**. Promoted the existing H2 \"The Crooked House at Homecoming Park Donors\" to H1.

**/become-a-friend/** — had **zero H1 tags**. Promoted the existing H2 \"the Crooked House\" to H1 (it's the page title).

**/donors/** also had one straggler unquoted \`alt=IMG_1567.jpg\` not caught by the prior pass — replaced with \"Donors thank-you image\".

## Not in scope
**/press/** is already structurally correct (single H1 \"PRESS\"). Its multiple empty \`<h2>&nbsp;</h2>\` and \`<h3>&nbsp;</h3>\` spacer tags are a separate, more invasive content cleanup.

## Test plan
- [ ] axe DevTools / Lighthouse — \"Page has a level-one heading\" no longer fails on /donors/ or /become-a-friend/
- [ ] Visual check: page titles render at the same size as before (CSS targets \`.Index-page-title\` etc., not the tag name)
- [ ] No unquoted filename alt remains on /donors/