### PR TITLE
Perf: add loading=lazy and width/height to images

### DIFF
--- a/become-a-friend/index.html
+++ b/become-a-friend/index.html
@@ -135,7 +135,7 @@
  <div class="Footer-inner clear" id=yui_3_17_2_1_1761695033349_75>
  <div class="sqs-layout sqs-grid-12 columns-12 Footer-blocks Footer-blocks--top sqs-alternate-block-style-container" data-layout-label="Footer Top Blocks" data-type=block-field data-updated-on=1472821757384 id=footerBlocksTop><div class="row sqs-row" id=yui_3_17_2_1_1761695033349_74><div class="col sqs-col-12 span-12" id=yui_3_17_2_1_1761695033349_73><div class="sqs-block image-block sqs-block-image sqs-text-ready" data-block-type=5 id=block-yui_3_17_2_15_1472529195900_10875><div class=sqs-block-content>
 <div style="text-align:center;padding:20px 10px;">
-<img src="../images/centre-gives-logo.png" alt="Centre Gives - A Project of Centre Foundation" style="max-width:400px;width:100%;height:auto;">
+<img width="515" height="400" src="../images/centre-gives-logo.png" alt="Centre Gives - A Project of Centre Foundation" style="max-width:400px;width:100%;height:auto;">
 <p style="margin-top:15px;font-family:sans-serif;font-size:15px;color:#555;max-width:500px;margin-left:auto;margin-right:auto;">Thank you to Centre Gives and the Centre Foundation for the work they do to support Centre County nonprofits.</p>
 </div>
 </div></div></div></div></div>

--- a/donors/index.html
+++ b/donors/index.html
@@ -52,7 +52,7 @@
  
  <div class=Parallax-item data-parallax-item data-parallax-id=57df0fc4197aea80c360393f style=top:0px;left:0px;width:1710px;height:183px;transform:translate3d(0px,0px,0px)><figure class="Intro-image loaded" data-parallax-image-wrapper style=top:-300px;overflow:hidden;transform:translate3d(0px,258.755px,0px)>
  
- <img data-src=https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1474242119990-358VE343NI7Y0AW9IHLM/IMG_1567.jpg data-image=https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1474242119990-358VE343NI7Y0AW9IHLM/IMG_1567.jpg data-image-dimensions=1653x612 data-image-focal-point=0.54,0.74 data-load=false data-parent-ratio=3.5 alt="Donors thank-you image" data-image-resolution=2500w src="../images/inline/inline-15b356cd85.webp" style=font-size:0px;left:-2.27374e-13px;top:-150.103px;width:1710px;height:633.103px;position:relative>
+ <img width="1653" height="612" data-src=https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1474242119990-358VE343NI7Y0AW9IHLM/IMG_1567.jpg data-image=https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1474242119990-358VE343NI7Y0AW9IHLM/IMG_1567.jpg data-image-dimensions=1653x612 data-image-focal-point=0.54,0.74 data-load=false data-parent-ratio=3.5 alt="Donors thank-you image" data-image-resolution=2500w src="../images/inline/inline-15b356cd85.webp" style=font-size:0px;left:-2.27374e-13px;top:-150.103px;width:1710px;height:633.103px;position:relative>
  </figure></div>
  
  
@@ -167,7 +167,7 @@
 </div>
 </div></div></div></div><div class="row sqs-row"><div class="col sqs-col-12 span-12"><div class="row sqs-row"><div class="col sqs-col-5 span-5"><div class="sqs-block website-component-block sqs-block-website-component sqs-block-spacer spacer-block sized vsize-1" data-block-css='["https://definitions.sqspcdn.com/website-component-definition/static-assets/website.components.spacer/465a6f7e-a77e-40d9-aa07-324f4d1974f2_277/website.components.spacer.styles.css"]' data-block-scripts='["https://definitions.sqspcdn.com/website-component-definition/static-assets/website.components.spacer/465a6f7e-a77e-40d9-aa07-324f4d1974f2_277/website.components.spacer.visitor.js"]' data-block-type=1337 data-definition-name=website.components.spacer id=block-yui_3_17_2_1_1577576025817_11743><div class=sqs-block-content>&nbsp;</div></div></div><div class="col sqs-col-7 span-7"><div class="sqs-block code-block sqs-block-code" data-block-type=23 id=block-yui_3_17_2_1_1577575719777_12662><div class=sqs-block-content><form action=https://www.paypal.com/cgi-bin/webscr method=post target=_top>
 <input type=image src="../images/inline/inline-10d6bc1ecc.gif" border=0 name=submit title="PayPal - The safer, easier way to pay online!" alt="Donate with PayPal button" value>
-<img alt border=0 src="../images/inline/inline-9abbdd35f0.gif" width=1 height=1>
+<img loading=lazy alt border=0 src="../images/inline/inline-9abbdd35f0.gif" width=1 height=1>
 </form>
 </div></div></div></div></div></div></div>
  </section>
@@ -179,7 +179,7 @@
  <div class="Footer-inner clear" id=yui_3_17_2_1_1761695020842_75>
  <div class="sqs-layout sqs-grid-12 columns-12 Footer-blocks Footer-blocks--top sqs-alternate-block-style-container" data-layout-label="Footer Top Blocks" data-type=block-field data-updated-on=1472821757384 id=footerBlocksTop><div class="row sqs-row" id=yui_3_17_2_1_1761695020842_74><div class="col sqs-col-12 span-12" id=yui_3_17_2_1_1761695020842_73><div class="sqs-block image-block sqs-block-image sqs-text-ready" data-block-type=5 id=block-yui_3_17_2_15_1472529195900_10875><div class=sqs-block-content>
 <div style="text-align:center;padding:20px 10px;">
-<img src="../images/centre-gives-logo.png" alt="Centre Gives - A Project of Centre Foundation" style="max-width:400px;width:100%;height:auto;">
+<img width="515" height="400" loading=lazy src="../images/centre-gives-logo.png" alt="Centre Gives - A Project of Centre Foundation" style="max-width:400px;width:100%;height:auto;">
 <p style="margin-top:15px;font-family:sans-serif;font-size:15px;color:#555;max-width:500px;margin-left:auto;margin-right:auto;">Thank you to Centre Gives and the Centre Foundation for the work they do to support Centre County nonprofits.</p>
 </div>
 </div></div></div></div></div>

--- a/index.html
+++ b/index.html
@@ -510,7 +510,7 @@
  
  <div class=Parallax-item data-parallax-item data-parallax-id=57c4f6ddf7e0ab9190e16ea1 style=top:140px;left:0px;width:1710px;height:1918px;transform:translate3d(0px,0px,0px)><figure class="Index-page-image loaded" data-parallax-image-wrapper style=top:-300px;overflow:hidden;transform:translate3d(0px,-34.7208px,0px)>
  
- <img data-src=https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1476053647950-VD31WVZ1TG85YPFWY6P7/banner4-02.jpg data-image=https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1476053647950-VD31WVZ1TG85YPFWY6P7/banner4-02.jpg data-image-dimensions=738x400 data-image-focal-point=0.5,0.5 data-load=false data-parent-ratio=0.8 alt="" data-image-resolution=2500w src="images/inline/inline-5fbae4f2c5.webp" style=font-size:0px;left:-1191.11px;top:0px;width:4092.21px;height:2218px;position:relative>
+ <img width="1600" height="867" data-src=https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1476053647950-VD31WVZ1TG85YPFWY6P7/banner4-02.jpg data-image=https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1476053647950-VD31WVZ1TG85YPFWY6P7/banner4-02.jpg data-image-dimensions=738x400 data-image-focal-point=0.5,0.5 data-load=false data-parent-ratio=0.8 alt="" data-image-resolution=2500w src="images/inline/inline-5fbae4f2c5.webp" style=font-size:0px;left:-1191.11px;top:0px;width:4092.21px;height:2218px;position:relative>
  </figure></div>
  
  
@@ -520,7 +520,7 @@
  
  <div class=Parallax-item data-parallax-item data-parallax-id=57e9d02ce58c62718a9fa402 style=top:2056px;left:0px;width:1710px;height:724px;transform:translate3d(-1710px,0px,0px)><figure class="Index-page-image loaded" data-parallax-image-wrapper style=top:-300px;overflow:hidden>
  
- <img data-src=https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1474941829634-QEII8P8G3AFUBDKJJVQL/blue-bg.jpg data-image=https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1474941829634-QEII8P8G3AFUBDKJJVQL/blue-bg.jpg data-image-dimensions=1600x400 data-image-focal-point=0.6848739495798319,0.47478991596638653 data-load=false data-parent-ratio=1.7 alt="" data-image-resolution=2500w src=images/inline/inline-aed3178dcf.webp style=font-size:0px;left:-1950.24px;top:0px;width:4096px;height:1024px;position:relative>
+ <img width="1600" height="400" data-src=https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1474941829634-QEII8P8G3AFUBDKJJVQL/blue-bg.jpg data-image=https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1474941829634-QEII8P8G3AFUBDKJJVQL/blue-bg.jpg data-image-dimensions=1600x400 data-image-focal-point=0.6848739495798319,0.47478991596638653 data-load=false data-parent-ratio=1.7 alt="" data-image-resolution=2500w src=images/inline/inline-aed3178dcf.webp style=font-size:0px;left:-1950.24px;top:0px;width:4096px;height:1024px;position:relative>
  </figure></div>
  
  
@@ -535,7 +535,7 @@
  
  <div class=Parallax-item data-parallax-item data-parallax-id=57c507a86b8f5b269969d361 style=top:3681px;left:0px;width:1710px;height:740px;transform:translate3d(-1710px,0px,0px)><figure class="Index-page-image loaded" data-parallax-image-wrapper style=top:-300px;overflow:hidden>
  
- <img data-src=https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1472909992334-URHU4KRB3JD3RUEF0PBG/essence-bg-02.jpg data-image=https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1472909992334-URHU4KRB3JD3RUEF0PBG/essence-bg-02.jpg data-image-dimensions=1600x1066 data-image-focal-point=0.5,0.5 data-load=false data-parent-ratio=1.6 alt="" data-image-resolution=2500w src=images/inline/inline-e4e4e6202e.webp style=font-size:0px;left:-1.13687e-13px;top:-49.6437px;width:1710px;height:1139.29px;position:relative>
+ <img width="1600" height="1066" loading=lazy data-src=https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1472909992334-URHU4KRB3JD3RUEF0PBG/essence-bg-02.jpg data-image=https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1472909992334-URHU4KRB3JD3RUEF0PBG/essence-bg-02.jpg data-image-dimensions=1600x1066 data-image-focal-point=0.5,0.5 data-load=false data-parent-ratio=1.6 alt="" data-image-resolution=2500w src=images/inline/inline-e4e4e6202e.webp style=font-size:0px;left:-1.13687e-13px;top:-49.6437px;width:1710px;height:1139.29px;position:relative>
  </figure></div>
  
  
@@ -550,7 +550,7 @@
  
  <div class=Parallax-item data-parallax-item data-parallax-id=57c4fb58440243c93126d4e3 style=top:5956px;left:0px;width:1710px;height:196px;transform:translate3d(-1710px,0px,0px)><figure class="Index-page-image loaded" data-parallax-image-wrapper style=top:-300px;overflow:hidden>
  
- <img data-src=https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1472527581872-IMJ5OG56YEBM6UUSMPKT/20150502_131124_IMG_9411.jpg data-image=https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1472527581872-IMJ5OG56YEBM6UUSMPKT/20150502_131124_IMG_9411.jpg data-image-dimensions=1600x1067 data-image-focal-point=0.5,0.5 data-load=false data-parent-ratio=3.4 alt="The Crooked House sculpture during construction" data-image-resolution=2500w src="images/inline/inline-c37e00215d.webp" style=font-size:0px;left:-1.13687e-13px;top:-322.178px;width:1710px;height:1140.36px;position:relative>
+ <img width="1600" height="1067" loading=lazy data-src=https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1472527581872-IMJ5OG56YEBM6UUSMPKT/20150502_131124_IMG_9411.jpg data-image=https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1472527581872-IMJ5OG56YEBM6UUSMPKT/20150502_131124_IMG_9411.jpg data-image-dimensions=1600x1067 data-image-focal-point=0.5,0.5 data-load=false data-parent-ratio=3.4 alt="The Crooked House sculpture during construction" data-image-resolution=2500w src="images/inline/inline-c37e00215d.webp" style=font-size:0px;left:-1.13687e-13px;top:-322.178px;width:1710px;height:1140.36px;position:relative>
  </figure></div>
  
  
@@ -689,7 +689,7 @@
  
  <span class=v6-visually-hidden>View fullsize</span>
  
- <noscript><img src="https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1472907442941-POGDKFY4AF43XGOT9KBV/13613563_10153834490481915_668322719579670_o.jpg" alt="The Crooked House sculpture"></noscript><img class="thumb-image loaded" elementtiming=system-gallery-block-grid data-src=https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1472907442941-POGDKFY4AF43XGOT9KBV/13613563_10153834490481915_668322719579670_o.jpg data-image=https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1472907442941-POGDKFY4AF43XGOT9KBV/13613563_10153834490481915_668322719579670_o.jpg data-image-dimensions=1024x768 data-image-focal-point=0.5,0.5 data-load=false data-image-id=57cac8b2bebafb5698fe38f1 data-type=image style=left:-21.8333px;top:0px;width:174.667px;height:131px;position:relative data-parent-ratio=1.0 alt="The Crooked House sculpture" data-image-resolution=500w src=images/inline/inline-7df76ef290.webp>
+ <noscript><img loading=lazy src="https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1472907442941-POGDKFY4AF43XGOT9KBV/13613563_10153834490481915_668322719579670_o.jpg" alt="The Crooked House sculpture"></noscript><img width="500" height="375" loading=lazy class="thumb-image loaded" elementtiming=system-gallery-block-grid data-src=https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1472907442941-POGDKFY4AF43XGOT9KBV/13613563_10153834490481915_668322719579670_o.jpg data-image=https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1472907442941-POGDKFY4AF43XGOT9KBV/13613563_10153834490481915_668322719579670_o.jpg data-image-dimensions=1024x768 data-image-focal-point=0.5,0.5 data-load=false data-image-id=57cac8b2bebafb5698fe38f1 data-type=image style=left:-21.8333px;top:0px;width:174.667px;height:131px;position:relative data-parent-ratio=1.0 alt="The Crooked House sculpture" data-image-resolution=500w src=images/inline/inline-7df76ef290.webp>
  </a>
  
  </div>
@@ -709,7 +709,7 @@
  
  <span class=v6-visually-hidden>View fullsize</span>
  
- <noscript><img src="https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1472907473278-MX6Y7SDP2QLMN1NJVC99/DSC_0020+%28baf120%40psu.edu%29.jpg" alt="The Crooked House at Homecoming Park"></noscript><img class="thumb-image loaded" elementtiming=system-gallery-block-grid data-src=https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1472907473278-MX6Y7SDP2QLMN1NJVC99/DSC_0020+%28baf120%40psu.edu%29.jpg data-image=https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1472907473278-MX6Y7SDP2QLMN1NJVC99/DSC_0020+%28baf120%40psu.edu%29.jpg data-image-dimensions=1600x1063 data-image-focal-point=0.4897959183673469,0.0 data-load=false data-image-id=57cac8d0bebafb5698fe397a data-type=image style=left:-31.0769px;top:0px;width:197.178px;height:131px;position:relative data-parent-ratio=1.0 alt="The Crooked House at Homecoming Park" data-image-resolution=500w src=images/inline/inline-a49caf8208.webp>
+ <noscript><img loading=lazy src="https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1472907473278-MX6Y7SDP2QLMN1NJVC99/DSC_0020+%28baf120%40psu.edu%29.jpg" alt="The Crooked House at Homecoming Park"></noscript><img width="500" height="332" loading=lazy class="thumb-image loaded" elementtiming=system-gallery-block-grid data-src=https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1472907473278-MX6Y7SDP2QLMN1NJVC99/DSC_0020+%28baf120%40psu.edu%29.jpg data-image=https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1472907473278-MX6Y7SDP2QLMN1NJVC99/DSC_0020+%28baf120%40psu.edu%29.jpg data-image-dimensions=1600x1063 data-image-focal-point=0.4897959183673469,0.0 data-load=false data-image-id=57cac8d0bebafb5698fe397a data-type=image style=left:-31.0769px;top:0px;width:197.178px;height:131px;position:relative data-parent-ratio=1.0 alt="The Crooked House at Homecoming Park" data-image-resolution=500w src=images/inline/inline-a49caf8208.webp>
  </a>
  
  </div>
@@ -729,7 +729,7 @@
  
  <span class=v6-visually-hidden>View fullsize</span>
  
- <noscript><img src="https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1472907503309-798WCPDVYHRCKM5TJIJS/IMG_8129.jpg" alt="The Crooked House sculpture"></noscript><img class="thumb-image loaded" elementtiming=system-gallery-block-grid data-src=https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1472907503309-798WCPDVYHRCKM5TJIJS/IMG_8129.jpg data-image=https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1472907503309-798WCPDVYHRCKM5TJIJS/IMG_8129.jpg data-image-dimensions=2500x1803 data-image-focal-point=0.5,0.5 data-load=false data-image-id=57cac8ea1b631bb8d8d7cac4 data-type=image style=left:-25.3209px;top:0px;width:181.642px;height:131px;position:relative data-parent-ratio=1.0 alt="The Crooked House sculpture" data-image-resolution=500w src="images/inline/inline-162cdd6398.webp">
+ <noscript><img loading=lazy src="https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1472907503309-798WCPDVYHRCKM5TJIJS/IMG_8129.jpg" alt="The Crooked House sculpture"></noscript><img width="500" height="360" loading=lazy class="thumb-image loaded" elementtiming=system-gallery-block-grid data-src=https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1472907503309-798WCPDVYHRCKM5TJIJS/IMG_8129.jpg data-image=https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1472907503309-798WCPDVYHRCKM5TJIJS/IMG_8129.jpg data-image-dimensions=2500x1803 data-image-focal-point=0.5,0.5 data-load=false data-image-id=57cac8ea1b631bb8d8d7cac4 data-type=image style=left:-25.3209px;top:0px;width:181.642px;height:131px;position:relative data-parent-ratio=1.0 alt="The Crooked House sculpture" data-image-resolution=500w src="images/inline/inline-162cdd6398.webp">
  </a>
  
  </div>
@@ -749,7 +749,7 @@
  
  <span class=v6-visually-hidden>View fullsize</span>
  
- <noscript><img src="https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1474942733064-728ECX7KJ990FH6ATCV5/14358696_1775874472686073_5247345269486102013_n-1.jpg" alt="The Crooked House sculpture"></noscript><img class="thumb-image loaded" elementtiming=system-gallery-block-grid data-src=https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1474942733064-728ECX7KJ990FH6ATCV5/14358696_1775874472686073_5247345269486102013_n-1.jpg data-image=https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1474942733064-728ECX7KJ990FH6ATCV5/14358696_1775874472686073_5247345269486102013_n-1.jpg data-image-dimensions=792x594 data-image-focal-point=0.5,0.5 data-load=false data-image-id=57e9d70cb3db2be1c7d76c3a data-type=image style=left:-21.8333px;top:0px;width:174.667px;height:131px;position:relative data-parent-ratio=1.0 alt="The Crooked House sculpture" data-image-resolution=500w src=images/inline/inline-6ac0338f55.webp>
+ <noscript><img loading=lazy src="https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1474942733064-728ECX7KJ990FH6ATCV5/14358696_1775874472686073_5247345269486102013_n-1.jpg" alt="The Crooked House sculpture"></noscript><img width="500" height="375" loading=lazy class="thumb-image loaded" elementtiming=system-gallery-block-grid data-src=https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1474942733064-728ECX7KJ990FH6ATCV5/14358696_1775874472686073_5247345269486102013_n-1.jpg data-image=https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1474942733064-728ECX7KJ990FH6ATCV5/14358696_1775874472686073_5247345269486102013_n-1.jpg data-image-dimensions=792x594 data-image-focal-point=0.5,0.5 data-load=false data-image-id=57e9d70cb3db2be1c7d76c3a data-type=image style=left:-21.8333px;top:0px;width:174.667px;height:131px;position:relative data-parent-ratio=1.0 alt="The Crooked House sculpture" data-image-resolution=500w src=images/inline/inline-6ac0338f55.webp>
  </a>
  
  </div>
@@ -769,7 +769,7 @@
  
  <span class=v6-visually-hidden>View fullsize</span>
  
- <noscript><img src="https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1729488868033-HDRRNCFRAWB0JEG4YCIV/IMG_2876.jpeg" alt="The Crooked House sculpture"></noscript><img class="thumb-image loaded" elementtiming=system-gallery-block-grid data-src=https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1729488868033-HDRRNCFRAWB0JEG4YCIV/IMG_2876.jpeg data-image=https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1729488868033-HDRRNCFRAWB0JEG4YCIV/IMG_2876.jpeg data-image-dimensions=4032x3024 data-image-focal-point=0.5,0.5 data-load=false data-image-id=6715e7e273121e339c3b3e43 data-type=image style=left:-21.8333px;top:0px;width:174.667px;height:131px;position:relative data-parent-ratio=1.0 alt="The Crooked House sculpture" data-image-resolution=500w src=images/inline/inline-e7642f0df5.webp>
+ <noscript><img loading=lazy src="https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1729488868033-HDRRNCFRAWB0JEG4YCIV/IMG_2876.jpeg" alt="The Crooked House sculpture"></noscript><img width="500" height="375" loading=lazy class="thumb-image loaded" elementtiming=system-gallery-block-grid data-src=https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1729488868033-HDRRNCFRAWB0JEG4YCIV/IMG_2876.jpeg data-image=https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1729488868033-HDRRNCFRAWB0JEG4YCIV/IMG_2876.jpeg data-image-dimensions=4032x3024 data-image-focal-point=0.5,0.5 data-load=false data-image-id=6715e7e273121e339c3b3e43 data-type=image style=left:-21.8333px;top:0px;width:174.667px;height:131px;position:relative data-parent-ratio=1.0 alt="The Crooked House sculpture" data-image-resolution=500w src=images/inline/inline-e7642f0df5.webp>
  </a>
  
  </div>
@@ -789,7 +789,7 @@
  
  <span class=v6-visually-hidden>View fullsize</span>
  
- <noscript><img src="https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1729489020415-OJAHDAICNKFFBKSU8MX7/IMG_8233-2+copy.jpg" alt="The Crooked House construction detail"></noscript><img class="thumb-image loaded" elementtiming=system-gallery-block-grid data-src=https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1729489020415-OJAHDAICNKFFBKSU8MX7/IMG_8233-2+copy.jpg data-image=https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1729489020415-OJAHDAICNKFFBKSU8MX7/IMG_8233-2+copy.jpg data-image-dimensions=3065x3065 data-image-focal-point=0.5,0.5 data-load=false data-image-id=6715e87bbc00be140c479571 data-type=image style=left:0px;top:0px;width:131px;height:131px;position:relative data-parent-ratio=1.0 alt="The Crooked House construction detail" data-image-resolution=300w src=images/inline/inline-1264da12a5.webp>
+ <noscript><img loading=lazy src="https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1729489020415-OJAHDAICNKFFBKSU8MX7/IMG_8233-2+copy.jpg" alt="The Crooked House construction detail"></noscript><img width="300" height="300" loading=lazy class="thumb-image loaded" elementtiming=system-gallery-block-grid data-src=https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1729489020415-OJAHDAICNKFFBKSU8MX7/IMG_8233-2+copy.jpg data-image=https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1729489020415-OJAHDAICNKFFBKSU8MX7/IMG_8233-2+copy.jpg data-image-dimensions=3065x3065 data-image-focal-point=0.5,0.5 data-load=false data-image-id=6715e87bbc00be140c479571 data-type=image style=left:0px;top:0px;width:131px;height:131px;position:relative data-parent-ratio=1.0 alt="The Crooked House construction detail" data-image-resolution=300w src=images/inline/inline-1264da12a5.webp>
  </a>
  
  </div>
@@ -809,7 +809,7 @@
  
  <span class=v6-visually-hidden>View fullsize</span>
  
- <noscript><img src="https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1729489111968-L8PAEF952W83Y0XD4ZR5/IMG_9658.jpg" alt="The Crooked House sculpture"></noscript><img class="thumb-image loaded" elementtiming=system-gallery-block-grid data-src=https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1729489111968-L8PAEF952W83Y0XD4ZR5/IMG_9658.jpg data-image=https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1729489111968-L8PAEF952W83Y0XD4ZR5/IMG_9658.jpg data-image-dimensions=2448x3264 data-image-focal-point=0.5,0.5 data-load=false data-image-id=6715e8d6da31b53ff6d08923 data-type=image style=left:0px;top:-21.8333px;width:131px;height:174.667px;position:relative data-parent-ratio=1.0 alt="The Crooked House sculpture" data-image-resolution=300w src="images/inline/inline-a9bc959431.webp">
+ <noscript><img loading=lazy src="https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1729489111968-L8PAEF952W83Y0XD4ZR5/IMG_9658.jpg" alt="The Crooked House sculpture"></noscript><img width="300" height="400" loading=lazy class="thumb-image loaded" elementtiming=system-gallery-block-grid data-src=https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1729489111968-L8PAEF952W83Y0XD4ZR5/IMG_9658.jpg data-image=https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1729489111968-L8PAEF952W83Y0XD4ZR5/IMG_9658.jpg data-image-dimensions=2448x3264 data-image-focal-point=0.5,0.5 data-load=false data-image-id=6715e8d6da31b53ff6d08923 data-type=image style=left:0px;top:-21.8333px;width:131px;height:174.667px;position:relative data-parent-ratio=1.0 alt="The Crooked House sculpture" data-image-resolution=300w src="images/inline/inline-a9bc959431.webp">
  </a>
  
  </div>
@@ -829,7 +829,7 @@
  
  <span class=v6-visually-hidden>View fullsize</span>
  
- <noscript><img src="https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1729489302851-CBGSHWMD10CLRK9FMYNK/IMG_8093.jpg" alt="The Crooked House sculpture"></noscript><img class="thumb-image loaded" elementtiming=system-gallery-block-grid data-src=https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1729489302851-CBGSHWMD10CLRK9FMYNK/IMG_8093.jpg data-image=https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1729489302851-CBGSHWMD10CLRK9FMYNK/IMG_8093.jpg data-image-dimensions=2448x3264 data-image-focal-point=0.5,0.5 data-load=false data-image-id=6715e996562d330726e88397 data-type=image style=left:0px;top:-21.8333px;width:131px;height:174.667px;position:relative data-parent-ratio=1.0 alt="The Crooked House sculpture" data-image-resolution=300w src="images/inline/inline-59b243ff7e.webp">
+ <noscript><img loading=lazy src="https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1729489302851-CBGSHWMD10CLRK9FMYNK/IMG_8093.jpg" alt="The Crooked House sculpture"></noscript><img width="300" height="400" loading=lazy class="thumb-image loaded" elementtiming=system-gallery-block-grid data-src=https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1729489302851-CBGSHWMD10CLRK9FMYNK/IMG_8093.jpg data-image=https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1729489302851-CBGSHWMD10CLRK9FMYNK/IMG_8093.jpg data-image-dimensions=2448x3264 data-image-focal-point=0.5,0.5 data-load=false data-image-id=6715e996562d330726e88397 data-type=image style=left:0px;top:-21.8333px;width:131px;height:174.667px;position:relative data-parent-ratio=1.0 alt="The Crooked House sculpture" data-image-resolution=300w src="images/inline/inline-59b243ff7e.webp">
  </a>
  
  </div>
@@ -849,7 +849,7 @@
  
  <span class=v6-visually-hidden>View fullsize</span>
  
- <noscript><img src="https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1729489319403-KBLDN3G1HO404PKD5NAJ/IMG_1863.jpeg" alt="The Crooked House facade"></noscript><img class="thumb-image loaded" elementtiming=system-gallery-block-grid data-src=https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1729489319403-KBLDN3G1HO404PKD5NAJ/IMG_1863.jpeg data-image=https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1729489319403-KBLDN3G1HO404PKD5NAJ/IMG_1863.jpeg data-image-dimensions=4032x3024 data-image-focal-point=0.5,0.5 data-load=false data-image-id=6715e9a50133582a7a1577ce data-type=image style=left:-21.8333px;top:0px;width:174.667px;height:131px;position:relative data-parent-ratio=1.0 alt="The Crooked House facade" data-image-resolution=500w src="images/inline/inline-92b408ebae.webp">
+ <noscript><img loading=lazy src="https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1729489319403-KBLDN3G1HO404PKD5NAJ/IMG_1863.jpeg" alt="The Crooked House facade"></noscript><img width="500" height="375" loading=lazy class="thumb-image loaded" elementtiming=system-gallery-block-grid data-src=https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1729489319403-KBLDN3G1HO404PKD5NAJ/IMG_1863.jpeg data-image=https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1729489319403-KBLDN3G1HO404PKD5NAJ/IMG_1863.jpeg data-image-dimensions=4032x3024 data-image-focal-point=0.5,0.5 data-load=false data-image-id=6715e9a50133582a7a1577ce data-type=image style=left:-21.8333px;top:0px;width:174.667px;height:131px;position:relative data-parent-ratio=1.0 alt="The Crooked House facade" data-image-resolution=500w src="images/inline/inline-92b408ebae.webp">
  </a>
  
  </div>
@@ -869,7 +869,7 @@
  
  <span class=v6-visually-hidden>View fullsize</span>
  
- <noscript><img src="https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1729489429478-XLJFEWUQAW2C9IBQEI8U/Jake+%26+Butch+mastermiding.jpeg" alt="Volunteers planning The Crooked House"></noscript><img class="thumb-image loaded" elementtiming=system-gallery-block-grid data-src=https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1729489429478-XLJFEWUQAW2C9IBQEI8U/Jake+%26+Butch+mastermiding.jpeg data-image=https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1729489429478-XLJFEWUQAW2C9IBQEI8U/Jake+%26+Butch+mastermiding.jpeg data-image-dimensions=3024x4032 data-image-focal-point=0.5,0.5 data-load=false data-image-id=6715ea13d32d4e06fed77cf6 data-type=image style=left:0px;top:-21.8333px;width:131px;height:174.667px;position:relative data-parent-ratio=1.0 alt="Volunteers planning The Crooked House" data-image-resolution=300w src="images/inline/inline-9130b6dfaa.webp">
+ <noscript><img loading=lazy src="https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1729489429478-XLJFEWUQAW2C9IBQEI8U/Jake+%26+Butch+mastermiding.jpeg" alt="Volunteers planning The Crooked House"></noscript><img width="300" height="400" loading=lazy class="thumb-image loaded" elementtiming=system-gallery-block-grid data-src=https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1729489429478-XLJFEWUQAW2C9IBQEI8U/Jake+%26+Butch+mastermiding.jpeg data-image=https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1729489429478-XLJFEWUQAW2C9IBQEI8U/Jake+%26+Butch+mastermiding.jpeg data-image-dimensions=3024x4032 data-image-focal-point=0.5,0.5 data-load=false data-image-id=6715ea13d32d4e06fed77cf6 data-type=image style=left:0px;top:-21.8333px;width:131px;height:174.667px;position:relative data-parent-ratio=1.0 alt="Volunteers planning The Crooked House" data-image-resolution=300w src="images/inline/inline-9130b6dfaa.webp">
  </a>
  
  </div>
@@ -889,7 +889,7 @@
  
  <span class=v6-visually-hidden>View fullsize</span>
  
- <noscript><img src="https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1729489499834-ABVUT2GPWMRNKXW9GXY3/Screen+Shot+2014-05-16+at+10.43.26+AM.png" alt="Early sketch of The Crooked House"></noscript><img class="thumb-image loaded" elementtiming=system-gallery-block-grid data-src=https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1729489499834-ABVUT2GPWMRNKXW9GXY3/Screen+Shot+2014-05-16+at+10.43.26+AM.png data-image=https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1729489499834-ABVUT2GPWMRNKXW9GXY3/Screen+Shot+2014-05-16+at+10.43.26+AM.png data-image-dimensions=343x218 data-image-focal-point=0.5,0.5 data-load=false data-image-id=6715ea5b59c8cb72c2497f98 data-type=image style=left:-37.5573px;top:0px;width:206.115px;height:131px;position:relative data-parent-ratio=1.0 alt="Early sketch of The Crooked House" data-image-resolution=500w src="images/inline/inline-a7cb26b676.webp">
+ <noscript><img loading=lazy src="https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1729489499834-ABVUT2GPWMRNKXW9GXY3/Screen+Shot+2014-05-16+at+10.43.26+AM.png" alt="Early sketch of The Crooked House"></noscript><img width="343" height="218" loading=lazy class="thumb-image loaded" elementtiming=system-gallery-block-grid data-src=https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1729489499834-ABVUT2GPWMRNKXW9GXY3/Screen+Shot+2014-05-16+at+10.43.26+AM.png data-image=https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1729489499834-ABVUT2GPWMRNKXW9GXY3/Screen+Shot+2014-05-16+at+10.43.26+AM.png data-image-dimensions=343x218 data-image-focal-point=0.5,0.5 data-load=false data-image-id=6715ea5b59c8cb72c2497f98 data-type=image style=left:-37.5573px;top:0px;width:206.115px;height:131px;position:relative data-parent-ratio=1.0 alt="Early sketch of The Crooked House" data-image-resolution=500w src="images/inline/inline-a7cb26b676.webp">
  </a>
  
  </div>
@@ -909,7 +909,7 @@
  
  <span class=v6-visually-hidden>View fullsize</span>
  
- <noscript><img src="https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1729489633016-F6DIR7Z5JA2P8E8DTEVH/IMG_5668.jpg" alt="The Crooked House sculpture"></noscript><img class="thumb-image loaded" elementtiming=system-gallery-block-grid data-src=https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1729489633016-F6DIR7Z5JA2P8E8DTEVH/IMG_5668.jpg data-image=https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1729489633016-F6DIR7Z5JA2P8E8DTEVH/IMG_5668.jpg data-image-dimensions=2448x3264 data-image-focal-point=0.5,0.5 data-load=false data-image-id=6715eadfd4b2a0310c727a31 data-type=image style=left:0px;top:-21.8333px;width:131px;height:174.667px;position:relative data-parent-ratio=1.0 alt="The Crooked House sculpture" data-image-resolution=300w src="images/inline/inline-45fe7f473a.webp">
+ <noscript><img loading=lazy src="https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1729489633016-F6DIR7Z5JA2P8E8DTEVH/IMG_5668.jpg" alt="The Crooked House sculpture"></noscript><img width="300" height="400" loading=lazy class="thumb-image loaded" elementtiming=system-gallery-block-grid data-src=https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1729489633016-F6DIR7Z5JA2P8E8DTEVH/IMG_5668.jpg data-image=https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1729489633016-F6DIR7Z5JA2P8E8DTEVH/IMG_5668.jpg data-image-dimensions=2448x3264 data-image-focal-point=0.5,0.5 data-load=false data-image-id=6715eadfd4b2a0310c727a31 data-type=image style=left:0px;top:-21.8333px;width:131px;height:174.667px;position:relative data-parent-ratio=1.0 alt="The Crooked House sculpture" data-image-resolution=300w src="images/inline/inline-45fe7f473a.webp">
  </a>
  
  </div>
@@ -929,7 +929,7 @@
  
  <span class=v6-visually-hidden>View fullsize</span>
  
- <noscript><img src="https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1729489769419-T1Q1WDKIP8ZLNIDGLCZQ/IMG_0911.jpg" alt="The Crooked House sculpture"></noscript><img class="thumb-image loaded" elementtiming=system-gallery-block-grid data-src=https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1729489769419-T1Q1WDKIP8ZLNIDGLCZQ/IMG_0911.jpg data-image=https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1729489769419-T1Q1WDKIP8ZLNIDGLCZQ/IMG_0911.jpg data-image-dimensions=2679x3185 data-image-focal-point=0.5,0.5 data-load=false data-image-id=6715eb68cb7cd82c37665c18 data-type=image style=left:0px;top:-12.3714px;width:131px;height:155.743px;position:relative data-parent-ratio=1.0 alt="The Crooked House sculpture" data-image-resolution=300w src="images/inline/inline-35b1c1af25.webp">
+ <noscript><img loading=lazy src="https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1729489769419-T1Q1WDKIP8ZLNIDGLCZQ/IMG_0911.jpg" alt="The Crooked House sculpture"></noscript><img width="300" height="357" loading=lazy class="thumb-image loaded" elementtiming=system-gallery-block-grid data-src=https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1729489769419-T1Q1WDKIP8ZLNIDGLCZQ/IMG_0911.jpg data-image=https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1729489769419-T1Q1WDKIP8ZLNIDGLCZQ/IMG_0911.jpg data-image-dimensions=2679x3185 data-image-focal-point=0.5,0.5 data-load=false data-image-id=6715eb68cb7cd82c37665c18 data-type=image style=left:0px;top:-12.3714px;width:131px;height:155.743px;position:relative data-parent-ratio=1.0 alt="The Crooked House sculpture" data-image-resolution=300w src="images/inline/inline-35b1c1af25.webp">
  </a>
  
  </div>
@@ -949,7 +949,7 @@
  
  <span class=v6-visually-hidden>View fullsize</span>
  
- <noscript><img src="https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1729490139216-CRGKY4WPT953IK948PFP/IMG_1672.jpeg" alt="The Crooked House sculpture"></noscript><img class="thumb-image loaded" elementtiming=system-gallery-block-grid data-src=https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1729490139216-CRGKY4WPT953IK948PFP/IMG_1672.jpeg data-image=https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1729490139216-CRGKY4WPT953IK948PFP/IMG_1672.jpeg data-image-dimensions=3024x4032 data-image-focal-point=0.5,0.5 data-load=false data-image-id=6715ecd88692445dd1039746 data-type=image style=left:0px;top:-21.8333px;width:131px;height:174.667px;position:relative data-parent-ratio=1.0 alt="The Crooked House sculpture" data-image-resolution=300w src="images/inline/inline-adec42c0c9.webp">
+ <noscript><img loading=lazy src="https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1729490139216-CRGKY4WPT953IK948PFP/IMG_1672.jpeg" alt="The Crooked House sculpture"></noscript><img width="300" height="400" loading=lazy class="thumb-image loaded" elementtiming=system-gallery-block-grid data-src=https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1729490139216-CRGKY4WPT953IK948PFP/IMG_1672.jpeg data-image=https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1729490139216-CRGKY4WPT953IK948PFP/IMG_1672.jpeg data-image-dimensions=3024x4032 data-image-focal-point=0.5,0.5 data-load=false data-image-id=6715ecd88692445dd1039746 data-type=image style=left:0px;top:-21.8333px;width:131px;height:174.667px;position:relative data-parent-ratio=1.0 alt="The Crooked House sculpture" data-image-resolution=300w src="images/inline/inline-adec42c0c9.webp">
  </a>
  
  </div>
@@ -969,7 +969,7 @@
  
  <span class=v6-visually-hidden>View fullsize</span>
  
- <noscript><img src="https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1729490047506-LWUOLGW6YZVPH1MXJYSN/IMG_0232.jpeg" alt="The Crooked House sculpture"></noscript><img class="thumb-image loaded" elementtiming=system-gallery-block-grid data-src=https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1729490047506-LWUOLGW6YZVPH1MXJYSN/IMG_0232.jpeg data-image=https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1729490047506-LWUOLGW6YZVPH1MXJYSN/IMG_0232.jpeg data-image-dimensions=4032x3024 data-image-focal-point=0.5,0.5 data-load=false data-image-id=6715ec7c7fe32942f5e2c9aa data-type=image style=left:-21.8333px;top:0px;width:174.667px;height:131px;position:relative data-parent-ratio=1.0 alt="The Crooked House sculpture" data-image-resolution=500w src=images/inline/inline-91eda3ff24.webp>
+ <noscript><img loading=lazy src="https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1729490047506-LWUOLGW6YZVPH1MXJYSN/IMG_0232.jpeg" alt="The Crooked House sculpture"></noscript><img width="500" height="375" loading=lazy class="thumb-image loaded" elementtiming=system-gallery-block-grid data-src=https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1729490047506-LWUOLGW6YZVPH1MXJYSN/IMG_0232.jpeg data-image=https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1729490047506-LWUOLGW6YZVPH1MXJYSN/IMG_0232.jpeg data-image-dimensions=4032x3024 data-image-focal-point=0.5,0.5 data-load=false data-image-id=6715ec7c7fe32942f5e2c9aa data-type=image style=left:-21.8333px;top:0px;width:174.667px;height:131px;position:relative data-parent-ratio=1.0 alt="The Crooked House sculpture" data-image-resolution=500w src=images/inline/inline-91eda3ff24.webp>
  </a>
  
  </div>
@@ -989,7 +989,7 @@
  
  <span class=v6-visually-hidden>View fullsize</span>
  
- <noscript><img src="https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1729490190942-U58FIJ5GE3MHZ6WSMBUU/IMG_9121.jpeg" alt="The Crooked House sculpture"></noscript><img class="thumb-image loaded" elementtiming=system-gallery-block-grid data-src=https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1729490190942-U58FIJ5GE3MHZ6WSMBUU/IMG_9121.jpeg data-image=https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1729490190942-U58FIJ5GE3MHZ6WSMBUU/IMG_9121.jpeg data-image-dimensions=3264x2448 data-image-focal-point=0.5,0.5 data-load=false data-image-id=6715ed0d55c3b24d2ac63e75 data-type=image style=left:-21.8333px;top:0px;width:174.667px;height:131px;position:relative data-parent-ratio=1.0 alt="The Crooked House sculpture" data-image-resolution=500w src="images/inline/inline-7cee3944c6.webp">
+ <noscript><img loading=lazy src="https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1729490190942-U58FIJ5GE3MHZ6WSMBUU/IMG_9121.jpeg" alt="The Crooked House sculpture"></noscript><img width="500" height="375" loading=lazy class="thumb-image loaded" elementtiming=system-gallery-block-grid data-src=https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1729490190942-U58FIJ5GE3MHZ6WSMBUU/IMG_9121.jpeg data-image=https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1729490190942-U58FIJ5GE3MHZ6WSMBUU/IMG_9121.jpeg data-image-dimensions=3264x2448 data-image-focal-point=0.5,0.5 data-load=false data-image-id=6715ed0d55c3b24d2ac63e75 data-type=image style=left:-21.8333px;top:0px;width:174.667px;height:131px;position:relative data-parent-ratio=1.0 alt="The Crooked House sculpture" data-image-resolution=500w src="images/inline/inline-7cee3944c6.webp">
  </a>
  
  </div>
@@ -1330,7 +1330,7 @@
 </div>
 </div></div><div class="row sqs-row"><div class="col sqs-col-5 span-5"><div class="sqs-block website-component-block sqs-block-website-component sqs-block-spacer spacer-block sized vsize-1" data-block-css='["https://definitions.sqspcdn.com/website-component-definition/static-assets/website.components.spacer/04d19983-fe18-4d11-af03-4a144136feeb_275/website.components.spacer.styles.css"]' data-block-scripts='["https://definitions.sqspcdn.com/website-component-definition/static-assets/website.components.spacer/04d19983-fe18-4d11-af03-4a144136feeb_275/website.components.spacer.visitor.js"]' data-block-type=1337 data-definition-name=website.components.spacer id=block-yui_3_17_2_1_1577577509699_8202><div class=sqs-block-content>&nbsp;</div></div></div><div class="col sqs-col-7 span-7"><div class="sqs-block code-block sqs-block-code" data-block-type=23 id=block-yui_3_17_2_1_1577577509699_8837><div class=sqs-block-content><form action=https://www.paypal.com/cgi-bin/webscr method=post target=_top>
 <input type=image src="images/inline/inline-10d6bc1ecc.gif" border=0 name=submit title="PayPal - The safer, easier way to pay online!" alt="Donate with PayPal button" value>
-<img alt border=0 src="images/inline/inline-9abbdd35f0.gif" width=1 height=1>
+<img loading=lazy alt border=0 src="images/inline/inline-9abbdd35f0.gif" width=1 height=1>
 </form>
 </div></div></div></div></div></div></div>
  </div>
@@ -1380,7 +1380,7 @@
  <div class="Footer-inner clear" id=yui_3_17_2_1_1761603656792_178>
  <div class="sqs-layout sqs-grid-12 columns-12 Footer-blocks Footer-blocks--top sqs-alternate-block-style-container" data-layout-label="Footer Top Blocks" data-type=block-field data-updated-on=1472821757384 id=footerBlocksTop><div class="row sqs-row" id=yui_3_17_2_1_1761603656792_177><div class="col sqs-col-12 span-12" id=yui_3_17_2_1_1761603656792_176><div class="sqs-block image-block sqs-block-image sqs-text-ready" data-block-type=5 id=block-yui_3_17_2_15_1472529195900_10875><div class=sqs-block-content>
 <div style="text-align:center;padding:20px 10px;">
-<img src="images/centre-gives-logo.png" alt="Centre Gives - A Project of Centre Foundation" style="max-width:400px;width:100%;height:auto;">
+<img width="515" height="400" loading=lazy src="images/centre-gives-logo.png" alt="Centre Gives - A Project of Centre Foundation" style="max-width:400px;width:100%;height:auto;">
 <p style="margin-top:15px;font-family:sans-serif;font-size:15px;color:#555;max-width:500px;margin-left:auto;margin-right:auto;">Thank you to Centre Gives and the Centre Foundation for the work they do to support Centre County nonprofits.</p>
 </div>
 </div></div></div></div></div>

--- a/press/index.html
+++ b/press/index.html
@@ -126,7 +126,7 @@
  <div class="Footer-inner clear" id=yui_3_17_2_1_1761695050331_75>
  <div class="sqs-layout sqs-grid-12 columns-12 Footer-blocks Footer-blocks--top sqs-alternate-block-style-container" data-layout-label="Footer Top Blocks" data-type=block-field data-updated-on=1472821757384 id=footerBlocksTop><div class="row sqs-row" id=yui_3_17_2_1_1761695050331_74><div class="col sqs-col-12 span-12" id=yui_3_17_2_1_1761695050331_73><div class="sqs-block image-block sqs-block-image sqs-text-ready" data-block-type=5 id=block-yui_3_17_2_15_1472529195900_10875><div class=sqs-block-content>
 <div style="text-align:center;padding:20px 10px;">
-<img src="../images/centre-gives-logo.png" alt="Centre Gives - A Project of Centre Foundation" style="max-width:400px;width:100%;height:auto;">
+<img width="515" height="400" src="../images/centre-gives-logo.png" alt="Centre Gives - A Project of Centre Foundation" style="max-width:400px;width:100%;height:auto;">
 <p style="margin-top:15px;font-family:sans-serif;font-size:15px;color:#555;max-width:500px;margin-left:auto;margin-right:auto;">Thank you to Centre Gives and the Centre Foundation for the work they do to support Centre County nonprofits.</p>
 </div>
 </div></div></div></div></div>


### PR DESCRIPTION
## Summary
Follow-up to #37 (base64 extraction). Now that images live as real files, add the two browser hints that matter most:

1. **\`loading=\"lazy\"\`** on every img except the first 2 in each page (preserves eager loading for the hero / above-the-fold imagery). The browser will defer fetches for off-screen images until the user scrolls near them.

2. **\`width=\` and \`height=\`** on every img whose \`src=\` resolves to a local file with known intrinsic dimensions. Lets the browser reserve correct aspect-ratio space before the image arrives — eliminates layout shift (CLS).

## Impact (per page)
| Page | <img> count | loading=lazy added | width/height added |
|---|---|---|---|
| / | 45 | 36 | 19 |
| /donors/ | 4 | 2 | 1 |
| /press/ | 1 | 0 | 0 |
| /become-a-friend/ | 1 | 0 | 0 |

(Press and BaF have a single image each — both above the fold and pointing to Squarespace CDN URLs we don't have intrinsic dimensions for. Skipped.)

## Test plan
- [ ] Lighthouse — \"Image elements have explicit width and height\" passes for the 21 newly-annotated images
- [ ] Lighthouse — \"Defer offscreen images\" no longer flags
- [ ] No CLS / layout shift on initial scroll of the home page
- [ ] Above-the-fold hero still loads immediately (no flash of empty space)