### PR TITLE
Per-image alt text on home page (post-visual-inspection)

### DIFF
--- a/index.html
+++ b/index.html
@@ -550,7 +550,7 @@
  
  <div class=Parallax-item data-parallax-item data-parallax-id=57c4fb58440243c93126d4e3 style=top:5956px;left:0px;width:1710px;height:196px;transform:translate3d(-1710px,0px,0px)><figure class="Index-page-image loaded" data-parallax-image-wrapper style=top:-300px;overflow:hidden>
  
- <img width="1600" height="1067" loading=lazy alt="The Crooked House sculpture during construction" src="images/inline/inline-c37e00215d.webp" style=font-size:0px;left:-1.13687e-13px;top:-322.178px;width:1710px;height:1140.36px;position:relative>
+ <img width="1600" height="1067" loading=lazy alt="The Crooked House under construction, with plywood-clad facade and the stone chimney in place" src="images/inline/inline-c37e00215d.webp" style=font-size:0px;left:-1.13687e-13px;top:-322.178px;width:1710px;height:1140.36px;position:relative>
  </figure></div>
  
  
@@ -689,7 +689,7 @@
  
  <span class=v6-visually-hidden>View fullsize</span>
  
- <noscript><img loading=lazy src="https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1472907442941-POGDKFY4AF43XGOT9KBV/13613563_10153834490481915_668322719579670_o.jpg" alt="The Crooked House sculpture"></noscript><img width="500" height="375" loading=lazy class="thumb-image loaded" elementtiming=system-gallery-block-grid style=left:-21.8333px;top:0px;width:174.667px;height:131px;position:relative alt="The Crooked House sculpture" src=images/inline/inline-7df76ef290.webp>
+ <noscript><img loading=lazy src="https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1472907442941-POGDKFY4AF43XGOT9KBV/13613563_10153834490481915_668322719579670_o.jpg" alt="The original 1857 red-brick house at 204 Market Street before its transformation"></noscript><img width="500" height="375" loading=lazy class="thumb-image loaded" elementtiming=system-gallery-block-grid style=left:-21.8333px;top:0px;width:174.667px;height:131px;position:relative alt="The original 1857 red-brick house at 204 Market Street before its transformation" src=images/inline/inline-7df76ef290.webp>
  </a>
  
  </div>
@@ -709,7 +709,7 @@
  
  <span class=v6-visually-hidden>View fullsize</span>
  
- <noscript><img loading=lazy src="https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1472907473278-MX6Y7SDP2QLMN1NJVC99/DSC_0020+%28baf120%40psu.edu%29.jpg" alt="The Crooked House at Homecoming Park"></noscript><img width="500" height="332" loading=lazy class="thumb-image loaded" elementtiming=system-gallery-block-grid style=left:-31.0769px;top:0px;width:197.178px;height:131px;position:relative alt="The Crooked House at Homecoming Park" src=images/inline/inline-a49caf8208.webp>
+ <noscript><img loading=lazy src="https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1472907473278-MX6Y7SDP2QLMN1NJVC99/DSC_0020+%28baf120%40psu.edu%29.jpg" alt="Architectural foam-board model of The Crooked House showing the white facade, fence, and stone chimney"></noscript><img width="500" height="332" loading=lazy class="thumb-image loaded" elementtiming=system-gallery-block-grid style=left:-31.0769px;top:0px;width:197.178px;height:131px;position:relative alt="Architectural foam-board model of The Crooked House showing the white facade, fence, and stone chimney" src=images/inline/inline-a49caf8208.webp>
  </a>
  
  </div>
@@ -729,7 +729,7 @@
  
  <span class=v6-visually-hidden>View fullsize</span>
  
- <noscript><img loading=lazy src="https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1472907503309-798WCPDVYHRCKM5TJIJS/IMG_8129.jpg" alt="The Crooked House sculpture"></noscript><img width="500" height="360" loading=lazy class="thumb-image loaded" elementtiming=system-gallery-block-grid style=left:-25.3209px;top:0px;width:181.642px;height:131px;position:relative alt="The Crooked House sculpture" src="images/inline/inline-162cdd6398.webp">
+ <noscript><img loading=lazy src="https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1472907503309-798WCPDVYHRCKM5TJIJS/IMG_8129.jpg" alt="Demolition of the original 1857 house in winter, with workers removing wood siding next to a flatbed truck"></noscript><img width="500" height="360" loading=lazy class="thumb-image loaded" elementtiming=system-gallery-block-grid style=left:-25.3209px;top:0px;width:181.642px;height:131px;position:relative alt="Demolition of the original 1857 house in winter, with workers removing wood siding next to a flatbed truck" src="images/inline/inline-162cdd6398.webp">
  </a>
  
  </div>
@@ -749,7 +749,7 @@
  
  <span class=v6-visually-hidden>View fullsize</span>
  
- <noscript><img loading=lazy src="https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1474942733064-728ECX7KJ990FH6ATCV5/14358696_1775874472686073_5247345269486102013_n-1.jpg" alt="The Crooked House sculpture"></noscript><img width="500" height="375" loading=lazy class="thumb-image loaded" elementtiming=system-gallery-block-grid style=left:-21.8333px;top:0px;width:174.667px;height:131px;position:relative alt="The Crooked House sculpture" src=images/inline/inline-6ac0338f55.webp>
+ <noscript><img loading=lazy src="https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1474942733064-728ECX7KJ990FH6ATCV5/14358696_1775874472686073_5247345269486102013_n-1.jpg" alt="Benjamin Fehl standing in front of the stone chimney during construction, with The Crooked House banner above"></noscript><img width="500" height="375" loading=lazy class="thumb-image loaded" elementtiming=system-gallery-block-grid style=left:-21.8333px;top:0px;width:174.667px;height:131px;position:relative alt="Benjamin Fehl standing in front of the stone chimney during construction, with The Crooked House banner above" src=images/inline/inline-6ac0338f55.webp>
  </a>
  
  </div>
@@ -769,7 +769,7 @@
  
  <span class=v6-visually-hidden>View fullsize</span>
  
- <noscript><img loading=lazy src="https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1729488868033-HDRRNCFRAWB0JEG4YCIV/IMG_2876.jpeg" alt="The Crooked House sculpture"></noscript><img width="500" height="375" loading=lazy class="thumb-image loaded" elementtiming=system-gallery-block-grid style=left:-21.8333px;top:0px;width:174.667px;height:131px;position:relative alt="The Crooked House sculpture" src=images/inline/inline-e7642f0df5.webp>
+ <noscript><img loading=lazy src="https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1729488868033-HDRRNCFRAWB0JEG4YCIV/IMG_2876.jpeg" alt="Two friends sharing a meal at a picnic table during a Crooked House project event"></noscript><img width="500" height="375" loading=lazy class="thumb-image loaded" elementtiming=system-gallery-block-grid style=left:-21.8333px;top:0px;width:174.667px;height:131px;position:relative alt="Two friends sharing a meal at a picnic table during a Crooked House project event" src=images/inline/inline-e7642f0df5.webp>
  </a>
  
  </div>
@@ -789,7 +789,7 @@
  
  <span class=v6-visually-hidden>View fullsize</span>
  
- <noscript><img loading=lazy src="https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1729489020415-OJAHDAICNKFFBKSU8MX7/IMG_8233-2+copy.jpg" alt="The Crooked House construction detail"></noscript><img width="300" height="300" loading=lazy class="thumb-image loaded" elementtiming=system-gallery-block-grid style=left:0px;top:0px;width:131px;height:131px;position:relative alt="The Crooked House construction detail" src=images/inline/inline-1264da12a5.webp>
+ <noscript><img loading=lazy src="https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1729489020415-OJAHDAICNKFFBKSU8MX7/IMG_8233-2+copy.jpg" alt="Four volunteers waving from inside the wood-framed shell of The Crooked House during construction"></noscript><img width="300" height="300" loading=lazy class="thumb-image loaded" elementtiming=system-gallery-block-grid style=left:0px;top:0px;width:131px;height:131px;position:relative alt="Four volunteers waving from inside the wood-framed shell of The Crooked House during construction" src=images/inline/inline-1264da12a5.webp>
  </a>
  
  </div>
@@ -809,7 +809,7 @@
  
  <span class=v6-visually-hidden>View fullsize</span>
  
- <noscript><img loading=lazy src="https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1729489111968-L8PAEF952W83Y0XD4ZR5/IMG_9658.jpg" alt="The Crooked House sculpture"></noscript><img width="300" height="400" loading=lazy class="thumb-image loaded" elementtiming=system-gallery-block-grid style=left:0px;top:-21.8333px;width:131px;height:174.667px;position:relative alt="The Crooked House sculpture" src="images/inline/inline-a9bc959431.webp">
+ <noscript><img loading=lazy src="https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1729489111968-L8PAEF952W83Y0XD4ZR5/IMG_9658.jpg" alt="Two visitors posing in front of the completed stone chimney, with potted mums at its base"></noscript><img width="300" height="400" loading=lazy class="thumb-image loaded" elementtiming=system-gallery-block-grid style=left:0px;top:-21.8333px;width:131px;height:174.667px;position:relative alt="Two visitors posing in front of the completed stone chimney, with potted mums at its base" src="images/inline/inline-a9bc959431.webp">
  </a>
  
  </div>
@@ -829,7 +829,7 @@
  
  <span class=v6-visually-hidden>View fullsize</span>
  
- <noscript><img loading=lazy src="https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1729489302851-CBGSHWMD10CLRK9FMYNK/IMG_8093.jpg" alt="The Crooked House sculpture"></noscript><img width="300" height="400" loading=lazy class="thumb-image loaded" elementtiming=system-gallery-block-grid style=left:0px;top:-21.8333px;width:131px;height:174.667px;position:relative alt="The Crooked House sculpture" src="images/inline/inline-59b243ff7e.webp">
+ <noscript><img loading=lazy src="https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1729489302851-CBGSHWMD10CLRK9FMYNK/IMG_8093.jpg" alt="Two volunteers sealing a concrete panel in the fabrication shop"></noscript><img width="300" height="400" loading=lazy class="thumb-image loaded" elementtiming=system-gallery-block-grid style=left:0px;top:-21.8333px;width:131px;height:174.667px;position:relative alt="Two volunteers sealing a concrete panel in the fabrication shop" src="images/inline/inline-59b243ff7e.webp">
  </a>
  
  </div>
@@ -849,7 +849,7 @@
  
  <span class=v6-visually-hidden>View fullsize</span>
  
- <noscript><img loading=lazy src="https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1729489319403-KBLDN3G1HO404PKD5NAJ/IMG_1863.jpeg" alt="The Crooked House facade"></noscript><img width="500" height="375" loading=lazy class="thumb-image loaded" elementtiming=system-gallery-block-grid style=left:-21.8333px;top:0px;width:174.667px;height:131px;position:relative alt="The Crooked House facade" src="images/inline/inline-92b408ebae.webp">
+ <noscript><img loading=lazy src="https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1729489319403-KBLDN3G1HO404PKD5NAJ/IMG_1863.jpeg" alt="A worker examining the cast-concrete facade panel laid flat in the fabrication shop"></noscript><img width="500" height="375" loading=lazy class="thumb-image loaded" elementtiming=system-gallery-block-grid style=left:-21.8333px;top:0px;width:174.667px;height:131px;position:relative alt="A worker examining the cast-concrete facade panel laid flat in the fabrication shop" src="images/inline/inline-92b408ebae.webp">
  </a>
  
  </div>
@@ -869,7 +869,7 @@
  
  <span class=v6-visually-hidden>View fullsize</span>
  
- <noscript><img loading=lazy src="https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1729489429478-XLJFEWUQAW2C9IBQEI8U/Jake+%26+Butch+mastermiding.jpeg" alt="Volunteers planning The Crooked House"></noscript><img width="300" height="400" loading=lazy class="thumb-image loaded" elementtiming=system-gallery-block-grid style=left:0px;top:-21.8333px;width:131px;height:174.667px;position:relative alt="Volunteers planning The Crooked House" src="images/inline/inline-9130b6dfaa.webp">
+ <noscript><img loading=lazy src="https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1729489429478-XLJFEWUQAW2C9IBQEI8U/Jake+%26+Butch+mastermiding.jpeg" alt="Two volunteers in conversation behind an open SUV with a wooden form between them"></noscript><img width="300" height="400" loading=lazy class="thumb-image loaded" elementtiming=system-gallery-block-grid style=left:0px;top:-21.8333px;width:131px;height:174.667px;position:relative alt="Two volunteers in conversation behind an open SUV with a wooden form between them" src="images/inline/inline-9130b6dfaa.webp">
  </a>
  
  </div>
@@ -889,7 +889,7 @@
  
  <span class=v6-visually-hidden>View fullsize</span>
  
- <noscript><img loading=lazy src="https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1729489499834-ABVUT2GPWMRNKXW9GXY3/Screen+Shot+2014-05-16+at+10.43.26+AM.png" alt="Early sketch of The Crooked House"></noscript><img width="343" height="218" loading=lazy class="thumb-image loaded" elementtiming=system-gallery-block-grid style=left:-37.5573px;top:0px;width:206.115px;height:131px;position:relative alt="Early sketch of The Crooked House" src="images/inline/inline-a7cb26b676.webp">
+ <noscript><img loading=lazy src="https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1729489499834-ABVUT2GPWMRNKXW9GXY3/Screen+Shot+2014-05-16+at+10.43.26+AM.png" alt="A volunteer working with a wheelbarrow of cement alongside the brick alley"></noscript><img width="343" height="218" loading=lazy class="thumb-image loaded" elementtiming=system-gallery-block-grid style=left:-37.5573px;top:0px;width:206.115px;height:131px;position:relative alt="A volunteer working with a wheelbarrow of cement alongside the brick alley" src="images/inline/inline-a7cb26b676.webp">
  </a>
  
  </div>
@@ -909,7 +909,7 @@
  
  <span class=v6-visually-hidden>View fullsize</span>
  
- <noscript><img loading=lazy src="https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1729489633016-F6DIR7Z5JA2P8E8DTEVH/IMG_5668.jpg" alt="The Crooked House sculpture"></noscript><img width="300" height="400" loading=lazy class="thumb-image loaded" elementtiming=system-gallery-block-grid style=left:0px;top:-21.8333px;width:131px;height:174.667px;position:relative alt="The Crooked House sculpture" src="images/inline/inline-45fe7f473a.webp">
+ <noscript><img loading=lazy src="https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1729489633016-F6DIR7Z5JA2P8E8DTEVH/IMG_5668.jpg" alt="A worker steadying jack supports at the base of the stone chimney during foundation work"></noscript><img width="300" height="400" loading=lazy class="thumb-image loaded" elementtiming=system-gallery-block-grid style=left:0px;top:-21.8333px;width:131px;height:174.667px;position:relative alt="A worker steadying jack supports at the base of the stone chimney during foundation work" src="images/inline/inline-45fe7f473a.webp">
  </a>
  
  </div>
@@ -929,7 +929,7 @@
  
  <span class=v6-visually-hidden>View fullsize</span>
  
- <noscript><img loading=lazy src="https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1729489769419-T1Q1WDKIP8ZLNIDGLCZQ/IMG_0911.jpg" alt="The Crooked House sculpture"></noscript><img width="300" height="357" loading=lazy class="thumb-image loaded" elementtiming=system-gallery-block-grid style=left:0px;top:-12.3714px;width:131px;height:155.743px;position:relative alt="The Crooked House sculpture" src="images/inline/inline-35b1c1af25.webp">
+ <noscript><img loading=lazy src="https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1729489769419-T1Q1WDKIP8ZLNIDGLCZQ/IMG_0911.jpg" alt="The completed Crooked House sculpture at sunset with sponsor banners on its black facade"></noscript><img width="300" height="357" loading=lazy class="thumb-image loaded" elementtiming=system-gallery-block-grid style=left:0px;top:-12.3714px;width:131px;height:155.743px;position:relative alt="The completed Crooked House sculpture at sunset with sponsor banners on its black facade" src="images/inline/inline-35b1c1af25.webp">
  </a>
  
  </div>
@@ -949,7 +949,7 @@
  
  <span class=v6-visually-hidden>View fullsize</span>
  
- <noscript><img loading=lazy src="https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1729490139216-CRGKY4WPT953IK948PFP/IMG_1672.jpeg" alt="The Crooked House sculpture"></noscript><img width="300" height="400" loading=lazy class="thumb-image loaded" elementtiming=system-gallery-block-grid style=left:0px;top:-21.8333px;width:131px;height:174.667px;position:relative alt="The Crooked House sculpture" src="images/inline/inline-adec42c0c9.webp">
+ <noscript><img loading=lazy src="https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1729490139216-CRGKY4WPT953IK948PFP/IMG_1672.jpeg" alt="Two volunteers shaping clay tiles at an outdoor workshop in front of the stone chimney"></noscript><img width="300" height="400" loading=lazy class="thumb-image loaded" elementtiming=system-gallery-block-grid style=left:0px;top:-21.8333px;width:131px;height:174.667px;position:relative alt="Two volunteers shaping clay tiles at an outdoor workshop in front of the stone chimney" src="images/inline/inline-adec42c0c9.webp">
  </a>
  
  </div>
@@ -969,7 +969,7 @@
  
  <span class=v6-visually-hidden>View fullsize</span>
  
- <noscript><img loading=lazy src="https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1729490047506-LWUOLGW6YZVPH1MXJYSN/IMG_0232.jpeg" alt="The Crooked House sculpture"></noscript><img width="500" height="375" loading=lazy class="thumb-image loaded" elementtiming=system-gallery-block-grid style=left:-21.8333px;top:0px;width:174.667px;height:131px;position:relative alt="The Crooked House sculpture" src=images/inline/inline-91eda3ff24.webp>
+ <noscript><img loading=lazy src="https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1729490047506-LWUOLGW6YZVPH1MXJYSN/IMG_0232.jpeg" alt="Three volunteers pouring concrete from a skid-steer bucket into the sidewalk forms"></noscript><img width="500" height="375" loading=lazy class="thumb-image loaded" elementtiming=system-gallery-block-grid style=left:-21.8333px;top:0px;width:174.667px;height:131px;position:relative alt="Three volunteers pouring concrete from a skid-steer bucket into the sidewalk forms" src=images/inline/inline-91eda3ff24.webp>
  </a>
  
  </div>
@@ -989,7 +989,7 @@
  
  <span class=v6-visually-hidden>View fullsize</span>
  
- <noscript><img loading=lazy src="https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1729490190942-U58FIJ5GE3MHZ6WSMBUU/IMG_9121.jpeg" alt="The Crooked House sculpture"></noscript><img width="500" height="375" loading=lazy class="thumb-image loaded" elementtiming=system-gallery-block-grid style=left:-21.8333px;top:0px;width:174.667px;height:131px;position:relative alt="The Crooked House sculpture" src="images/inline/inline-7cee3944c6.webp">
+ <noscript><img loading=lazy src="https://images.squarespace-cdn.com/content/v1/54d562b3e4b06ae542a5c6e8/1729490190942-U58FIJ5GE3MHZ6WSMBUU/IMG_9121.jpeg" alt="Two volunteers standing in front of the sculpture with a backhoe during groundwork"></noscript><img width="500" height="375" loading=lazy class="thumb-image loaded" elementtiming=system-gallery-block-grid style=left:-21.8333px;top:0px;width:174.667px;height:131px;position:relative alt="Two volunteers standing in front of the sculpture with a backhoe during groundwork" src="images/inline/inline-7cee3944c6.webp">
  </a>
  
  </div>
@@ -1155,7 +1155,7 @@
  
  
  
- <img data-stretch=false alt="Habitat for Humanity Volunteer badge" elementtiming=system-image-block src="images/inline/inline-c684df370a.webp" width=2500 height=2500 sizes style="display:block;object-fit:cover;width:100%;height:100%;object-position:50% 50%" srcset loading=lazy decoding=async data-loader=sqs class=loaded>
+ <img data-stretch=false alt="Happy Valley Adventure Bureau logo" elementtiming=system-image-block src="images/inline/inline-c684df370a.webp" width=2500 height=2500 sizes style="display:block;object-fit:cover;width:100%;height:100%;object-position:50% 50%" srcset loading=lazy decoding=async data-loader=sqs class=loaded>
  </div>
  </div>
  


### PR DESCRIPTION
## Summary
PRs #49 and #53 fixed alt text on the home page but used the generic placeholder \`alt=\"The Crooked House sculpture\"\` for every gallery thumbnail because the images were base64-inlined and I couldn't inspect them. After #37 made them real files, opened each one in turn and wrote a specific description.

### Highlights
- Original 1857 red-brick house (the \"before\")
- Architectural foam-board model
- Demolition in winter, workers removing siding
- Volunteers waving from inside the wood-framed shell
- Benjamin Fehl in front of the chimney during construction
- Foundation work with jack supports
- Concrete panel sealing in the fab shop
- Skid-steer pouring sidewalk concrete
- Backhoe groundwork
- Clay tile-making workshop
- Visitors with the completed chimney
- The completed sculpture at sunset with sponsor banners
- Plus several more

### Corrections
- **Happy Valley Adventure Bureau** logo was mis-labeled \"Habitat for Humanity Volunteer badge\" in #49 — that was based on the filename \"HV Badge\". Visual inspection: it's the Happy Valley logo (mountain lion silhouette, sun rays).

### Pairs synced
Each gallery slot has a \`<noscript>\` fallback img + a JS-loaded visible img. Both now share the new descriptive alt for the same image content.

## Stats
- 20 unique descriptive alts (was 6)
- 3 explicit \`alt=\"\"\` for true decorative items (parallax banner, blue spacer, chevron icon)
- Zero generic \"The Crooked House sculpture\" remain

## Test plan
- [ ] Hover any gallery image — tooltip shows a specific description, not the generic phrase
- [ ] Screen reader announces unique alt text per gallery thumbnail