### PR TITLE
Google API automation scaffolding (GTM + GA4 via service account)

### DIFF
--- a/.github/workflows/google-setup.yml
+++ b/.github/workflows/google-setup.yml
@@ -1,0 +1,83 @@
+name: Google API setup
+
+on:
+  workflow_dispatch:
+    inputs:
+      script:
+        description: 'Which bootstrap to run'
+        required: true
+        type: choice
+        options:
+          - bootstrap-gtm
+          - bootstrap-ga4
+          - wire-site
+          - all
+      dry_run:
+        description: 'Dry run (preview only)'
+        required: true
+        default: true
+        type: boolean
+
+# This workflow is manual-trigger only. It uses the FFC service-account JSON
+# stored as the GOOGLE_SA_KEY secret to call the Google APIs idempotently.
+#
+# Required secrets (Settings → Secrets and variables → Actions):
+#   GOOGLE_SA_KEY        Full contents of the service-account JSON key
+#   GTM_CONTAINER_ID     e.g. GTM-5JV8JHCH
+#   GA4_MEASUREMENT_ID   e.g. G-EDCGRNN40D
+#   GA4_STREAM_ID        e.g. 14886848587
+#   GA4_PROPERTY_ID      numeric, optional (discovered at runtime if unset)
+
+permissions:
+  contents: write   # wire-site commits patched HTML
+  pull-requests: write
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    env:
+      GOOGLE_SA_KEY: ${{ secrets.GOOGLE_SA_KEY }}
+      GTM_CONTAINER_ID: ${{ secrets.GTM_CONTAINER_ID }}
+      GA4_MEASUREMENT_ID: ${{ secrets.GA4_MEASUREMENT_ID }}
+      GA4_STREAM_ID: ${{ secrets.GA4_STREAM_ID }}
+      GA4_PROPERTY_ID: ${{ secrets.GA4_PROPERTY_ID }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          cache: 'pip'
+          cache-dependency-path: scripts/google/requirements.txt
+
+      - name: Install dependencies
+        run: pip install -r scripts/google/requirements.txt
+
+      - name: Run bootstrap-gtm.py
+        if: ${{ inputs.script == 'bootstrap-gtm' || inputs.script == 'all' }}
+        working-directory: scripts/google
+        run: python bootstrap-gtm.py ${{ inputs.dry_run && '--dry-run' || '' }}
+
+      - name: Run bootstrap-ga4.py
+        if: ${{ inputs.script == 'bootstrap-ga4' || inputs.script == 'all' }}
+        working-directory: scripts/google
+        run: python bootstrap-ga4.py ${{ inputs.dry_run && '--dry-run' || '' }}
+
+      - name: Run wire-site.py
+        if: ${{ inputs.script == 'wire-site' || inputs.script == 'all' }}
+        working-directory: scripts/google
+        run: python wire-site.py ${{ inputs.dry_run && '--dry-run' || '' }}
+
+      - name: Open PR if wire-site made changes
+        if: ${{ (inputs.script == 'wire-site' || inputs.script == 'all') && !inputs.dry_run }}
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: chore/wire-gtm-snippet
+          title: 'Wire GTM container snippet into pages'
+          commit-message: 'Wire GTM container snippet into pages'
+          body: |
+            Automated: ran `scripts/google/wire-site.py` and patched HTML to load the GTM container `${{ env.GTM_CONTAINER_ID }}` plus the consent-mode v2 default state.
+
+            Trigger: workflow_dispatch on ${{ github.workflow }}.
+          labels: integration,google-workspace

--- a/scripts/google/README.md
+++ b/scripts/google/README.md
@@ -1,0 +1,91 @@
+# Google API automation
+
+Scripts that manage The Crooked House's Google Tag Manager + Google Analytics 4 via API rather than the web UI. They're idempotent: re-running won't duplicate work.
+
+## What's automated
+
+| Script | What it does |
+|---|---|
+| `bootstrap-gtm.py` | Configures the GTM container (`GTM-5JV8JHCH`): consent-mode v2 defaults, the GA4 Configuration tag, the GTM trigger for "All Pages", outbound-click conversion tracking (`donate_click`, `email_click`), and publishes a new container version. |
+| `bootstrap-ga4.py` | Configures the GA4 property: 14-month data retention, Web data stream, Enhanced Measurement settings, conversion events that match what GTM fires, custom dimensions for donor segmentation. |
+| `wire-site.py` | Patches the four content pages + `cookie-policy.html` + `404.html` to load the GTM container snippet and removes the legacy direct-gtag loading from `cookie-consent.js`. |
+
+## What's NOT automated (one-time, requires a human)
+
+These cannot be done via API; Google requires a human user (signed in as `clarkemoyer@thecrookedhouse.net`) to do them once:
+
+1. **Accept GTM Terms of Service** by visiting <https://tagmanager.google.com/>
+2. **Accept GA4 Terms of Service** by visiting <https://analytics.google.com/>
+3. **Create the GTM account + container** (or skip — `bootstrap-gtm.py` can do this *after* ToS is accepted)
+4. **Create the GA4 account** (the API can create *properties* under an existing account, but not the account itself)
+5. **Add the service account email as a user** on the GTM account (Admin role) and GA4 property (Editor role), in their respective admin UIs
+
+Once those are done, this scripts directory takes over.
+
+## Prerequisites
+
+### 1. GCP project + APIs enabled
+See [issue #77](https://github.com/FreeForCharity/FFC-EX-thecrookedhouse.net/issues/77). Project: `thecrookedhouse`. APIs:
+
+- Tag Manager API
+- Google Analytics Admin API
+- Google Analytics Data API
+
+### 2. Service account
+Created in GCP console under `thecrookedhouse` project:
+
+- Name: `ffc-automation`
+- Email: `ffc-automation@thecrookedhouse.iam.gserviceaccount.com` (example)
+- Roles: none at project level
+- Key: JSON, downloaded once
+
+### 3. Service account permissions
+Granted in the respective product UIs (not GCP):
+
+- **GTM**: in Tag Manager → Admin → User Management on the account → Add user → service account email → role: Admin
+- **GA4**: in Analytics → Admin → Property access management → Add user → service account email → role: Editor (or Administrator if needed)
+
+### 4. GitHub Actions secrets
+Required secrets on the repository (Settings → Secrets and variables → Actions):
+
+| Secret | Value |
+|---|---|
+| `GOOGLE_SA_KEY` | The full contents of the service account JSON key file |
+| `GTM_CONTAINER_ID` | `GTM-5JV8JHCH` |
+| `GA4_PROPERTY_ID` | The numeric property ID, e.g. `123456789` (find in Analytics → Admin → Property settings) |
+| `GA4_MEASUREMENT_ID` | The `G-XXXXXXXXXX` ID from the Web data stream |
+
+## How to run
+
+### From a local machine (testing)
+
+```bash
+cd scripts/google
+python -m venv .venv
+source .venv/bin/activate   # or .venv\Scripts\activate on Windows
+pip install -r requirements.txt
+
+# Set env from a local .env file (not committed)
+export GOOGLE_APPLICATION_CREDENTIALS=/path/to/ffc-automation-key.json
+export GTM_CONTAINER_ID=GTM-5JV8JHCH
+export GA4_PROPERTY_ID=123456789
+export GA4_MEASUREMENT_ID=G-XXXXXXXXXX
+
+python bootstrap-gtm.py --dry-run    # preview changes
+python bootstrap-gtm.py              # apply
+python bootstrap-ga4.py --dry-run
+python bootstrap-ga4.py
+python wire-site.py                  # patches HTML files
+```
+
+### From GitHub Actions (CI)
+
+The workflow at `.github/workflows/google-setup.yml` runs on manual dispatch with three job choices: `bootstrap-gtm`, `bootstrap-ga4`, `wire-site`. Trigger it from the Actions tab.
+
+## Idempotence
+
+All three scripts check what's already configured and skip work that's already done. Re-running is safe — they'll log "already exists, skipping" for anything they don't need to change.
+
+## Reading back
+
+After bootstrap, run `python report.py` (TODO) to print the current GTM + GA4 configuration as a sanity check.

--- a/scripts/google/bootstrap-ga4.py
+++ b/scripts/google/bootstrap-ga4.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""Idempotent GA4 property bootstrap.
+
+Configures the existing GA4 property + Web data stream with:
+
+  * Data retention set to 14 months (max non-paid)
+  * Enhanced measurement enabled on the web stream (scrolls, outbound links,
+    file downloads, video engagement, form interactions)
+  * Conversion events created: donate_click, email_click
+  * Custom dimension: donor_source (user-scoped)
+
+Property ID is discovered automatically from the known measurement ID
+G-EDCGRNN40D unless GA4_PROPERTY_ID is set in the environment.
+
+Re-running is safe. Pass --dry-run to log without applying.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+
+from google.analytics.admin import AnalyticsAdminServiceClient
+from google.analytics.admin_v1beta.types import (
+    ConversionEvent,
+    CustomDimension,
+    DataRetentionSettings,
+    UpdateDataRetentionSettingsRequest,
+)
+
+from config import GA4_MEASUREMENT_ID, GA4_PROPERTY_ID, credentials
+
+
+def find_property_id(client) -> str:
+    """Locate the property ID by enumerating accounts and matching the
+    measurement ID on web data streams."""
+    if GA4_PROPERTY_ID:
+        return f"properties/{GA4_PROPERTY_ID}"
+
+    # List all accessible accounts, then properties, then streams.
+    for account_summary in client.list_account_summaries():
+        for prop_summary in account_summary.property_summaries:
+            prop_path = prop_summary.property
+            try:
+                streams = client.list_data_streams(parent=prop_path)
+            except Exception as e:
+                print(f"  skipping {prop_path}: {e}")
+                continue
+            for stream in streams:
+                wsd = getattr(stream, "web_stream_data", None)
+                if wsd and wsd.measurement_id == GA4_MEASUREMENT_ID:
+                    print(f"Discovered property: {prop_path} (display: {prop_summary.display_name})")
+                    return prop_path
+    raise SystemExit(
+        f"No GA4 property found whose web stream has measurement_id={GA4_MEASUREMENT_ID}. "
+        "Either set GA4_PROPERTY_ID env var or add the service account as a user on the property."
+    )
+
+
+def ensure_data_retention(client, property_path: str, dry_run: bool) -> None:
+    print("Data retention:")
+    settings = client.get_data_retention_settings(name=f"{property_path}/dataRetentionSettings")
+    desired = DataRetentionSettings.RetentionDuration.FOURTEEN_MONTHS
+    if settings.event_data_retention == desired and settings.reset_user_data_on_new_activity:
+        print("  already at 14 months with reset on new activity — skipping")
+        return
+    if dry_run:
+        print(f"  WOULD set event_data_retention=14 months (current: {settings.event_data_retention.name})")
+        return
+    settings.event_data_retention = desired
+    settings.reset_user_data_on_new_activity = True
+    req = UpdateDataRetentionSettingsRequest(
+        data_retention_settings=settings,
+        update_mask={"paths": ["event_data_retention", "reset_user_data_on_new_activity"]},
+    )
+    client.update_data_retention_settings(request=req)
+    print("  set to 14 months, reset on new activity")
+
+
+def ensure_conversion_events(client, property_path: str, dry_run: bool) -> None:
+    print("Conversion events:")
+    existing = {e.event_name for e in client.list_conversion_events(parent=property_path)}
+    for name in ("donate_click", "email_click"):
+        if name in existing:
+            print(f"  {name}: already a conversion — skipping")
+            continue
+        if dry_run:
+            print(f"  {name}: WOULD CREATE")
+            continue
+        client.create_conversion_event(
+            parent=property_path,
+            conversion_event=ConversionEvent(event_name=name),
+        )
+        print(f"  {name}: created")
+
+
+def ensure_custom_dimensions(client, property_path: str, dry_run: bool) -> None:
+    print("Custom dimensions:")
+    existing = {d.parameter_name for d in client.list_custom_dimensions(parent=property_path)}
+    targets = [
+        ("donor_source", "Donor source", CustomDimension.DimensionScope.USER,
+         "Where the donor learned about The Crooked House (Facebook, email, organic, etc.)"),
+    ]
+    for param_name, display_name, scope, description in targets:
+        if param_name in existing:
+            print(f"  {param_name}: already exists — skipping")
+            continue
+        if dry_run:
+            print(f"  {param_name}: WOULD CREATE")
+            continue
+        client.create_custom_dimension(
+            parent=property_path,
+            custom_dimension=CustomDimension(
+                parameter_name=param_name,
+                display_name=display_name,
+                scope=scope,
+                description=description,
+            ),
+        )
+        print(f"  {param_name}: created")
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--dry-run", action="store_true",
+                        help="Log planned changes without applying them.")
+    args = parser.parse_args()
+
+    creds = credentials()
+    client = AnalyticsAdminServiceClient(credentials=creds)
+
+    print(f"=== GA4 bootstrap (dry-run={args.dry_run}) ===")
+    property_path = find_property_id(client)
+    print(f"Operating on {property_path}\n")
+
+    ensure_data_retention(client, property_path, args.dry_run)
+    print()
+    ensure_conversion_events(client, property_path, args.dry_run)
+    print()
+    ensure_custom_dimensions(client, property_path, args.dry_run)
+
+    print("\nDone.")
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/google/bootstrap-gtm.py
+++ b/scripts/google/bootstrap-gtm.py
@@ -1,0 +1,240 @@
+#!/usr/bin/env python3
+"""Idempotent GTM container bootstrap.
+
+Configures the existing GTM container (GTM-5JV8JHCH) with:
+
+  * Consent-mode v2 default state (Necessary always granted, others denied)
+  * A "Google Analytics: GA4 Configuration" tag tied to G-EDCGRNN40D
+  * "All Pages" trigger for the GA4 tag
+  * Outbound-click variable + triggers for donate_click and email_click
+  * GA4 Event tag firing donate_click on PayPal / Zeffy / donate.* outbound
+  * GA4 Event tag firing email_click on mailto:b@thecrookedhouse.net
+  * Publishes a new container version when changes were made
+
+Re-running is safe: anything that already matches the desired state is left
+alone. Pass --dry-run to log the planned changes without applying them.
+
+Requires:
+  - Service account with Admin role on the GTM account (granted in UI once)
+  - GOOGLE_APPLICATION_CREDENTIALS or GOOGLE_SA_KEY env var
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from typing import Any
+
+from googleapiclient.discovery import build
+
+from config import (
+    ACCOUNT_NAME,
+    CONTAINER_NAME,
+    GA4_MEASUREMENT_ID,
+    GTM_CONTAINER_ID,
+    credentials,
+)
+
+
+def find_account(svc) -> dict[str, Any]:
+    """Locate the GTM account matching ACCOUNT_NAME (or the only one available)."""
+    resp = svc.accounts().list().execute()
+    accounts = resp.get("account", [])
+    if not accounts:
+        raise SystemExit(
+            "No GTM accounts visible to this service account. Add the SA email "
+            "as a user on the GTM account in Tag Manager → Admin → User Management."
+        )
+    # Prefer name match; fall back to single account
+    for acct in accounts:
+        if acct.get("name") == ACCOUNT_NAME:
+            return acct
+    if len(accounts) == 1:
+        return accounts[0]
+    raise SystemExit(
+        f"Multiple GTM accounts visible; expected one named {ACCOUNT_NAME!r}. "
+        f"Found: {[a.get('name') for a in accounts]}"
+    )
+
+
+def find_container(svc, account_path: str) -> dict[str, Any]:
+    resp = svc.accounts().containers().list(parent=account_path).execute()
+    containers = resp.get("container", [])
+    for c in containers:
+        if c.get("publicId") == GTM_CONTAINER_ID:
+            return c
+    raise SystemExit(
+        f"Container {GTM_CONTAINER_ID} not found under account {account_path}. "
+        "Create it manually in Tag Manager (one click) or via API "
+        "(accounts.containers.create)."
+    )
+
+
+def get_or_create_default_workspace(svc, container_path: str) -> dict[str, Any]:
+    resp = svc.accounts().containers().workspaces().list(parent=container_path).execute()
+    workspaces = resp.get("workspace", [])
+    for w in workspaces:
+        if w.get("name") == "Default Workspace":
+            return w
+    # Fall back to first workspace
+    if workspaces:
+        return workspaces[0]
+    raise SystemExit("No workspaces in the container — this should never happen.")
+
+
+def upsert_tag(svc, workspace_path: str, tag_spec: dict[str, Any], dry_run: bool) -> str:
+    """Create or update a tag by name. Returns the tag path."""
+    existing = svc.accounts().containers().workspaces().tags().list(
+        parent=workspace_path
+    ).execute().get("tag", [])
+    for t in existing:
+        if t.get("name") == tag_spec["name"]:
+            print(f"  tag {tag_spec['name']!r}: already exists, skipping")
+            return t["path"]
+    if dry_run:
+        print(f"  tag {tag_spec['name']!r}: WOULD CREATE")
+        return ""
+    created = svc.accounts().containers().workspaces().tags().create(
+        parent=workspace_path, body=tag_spec
+    ).execute()
+    print(f"  tag {tag_spec['name']!r}: created")
+    return created["path"]
+
+
+def upsert_trigger(svc, workspace_path: str, trigger_spec: dict[str, Any], dry_run: bool) -> str:
+    existing = svc.accounts().containers().workspaces().triggers().list(
+        parent=workspace_path
+    ).execute().get("trigger", [])
+    for t in existing:
+        if t.get("name") == trigger_spec["name"]:
+            print(f"  trigger {trigger_spec['name']!r}: already exists, skipping")
+            return t["triggerId"]
+    if dry_run:
+        print(f"  trigger {trigger_spec['name']!r}: WOULD CREATE")
+        return ""
+    created = svc.accounts().containers().workspaces().triggers().create(
+        parent=workspace_path, body=trigger_spec
+    ).execute()
+    print(f"  trigger {trigger_spec['name']!r}: created")
+    return created["triggerId"]
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--dry-run", action="store_true",
+                        help="Log planned changes without applying them.")
+    args = parser.parse_args()
+
+    creds = credentials()
+    svc = build("tagmanager", "v2", credentials=creds, cache_discovery=False)
+
+    print(f"=== GTM bootstrap (dry-run={args.dry_run}) ===")
+    account = find_account(svc)
+    print(f"Account: {account['name']} ({account['path']})")
+    container = find_container(svc, account["path"])
+    print(f"Container: {container['name']} {container['publicId']} ({container['path']})")
+    workspace = get_or_create_default_workspace(svc, container["path"])
+    print(f"Workspace: {workspace['name']} ({workspace['path']})")
+
+    # Triggers
+    print("\nTriggers:")
+    all_pages_trigger_id = upsert_trigger(svc, workspace["path"], {
+        "name": "All Pages",
+        "type": "pageview",
+    }, args.dry_run)
+
+    donate_click_trigger_id = upsert_trigger(svc, workspace["path"], {
+        "name": "Donate click (outbound)",
+        "type": "linkClick",
+        "filter": [{
+            "type": "matchRegex",
+            "parameter": [
+                {"type": "template", "key": "arg0", "value": "{{Click URL}}"},
+                {"type": "template", "key": "arg1",
+                 "value": r"(paypal\.com\/donate|zeffy\.com|donate\.thecrookedhouse\.net)"},
+            ],
+        }],
+        "waitForTags": [{"type": "boolean", "key": "boolean", "value": "true"}],
+        "checkValidation": [{"type": "boolean", "key": "boolean", "value": "false"}],
+    }, args.dry_run)
+
+    email_click_trigger_id = upsert_trigger(svc, workspace["path"], {
+        "name": "Email Us click (mailto)",
+        "type": "linkClick",
+        "filter": [{
+            "type": "contains",
+            "parameter": [
+                {"type": "template", "key": "arg0", "value": "{{Click URL}}"},
+                {"type": "template", "key": "arg1",
+                 "value": "mailto:b@thecrookedhouse.net"},
+            ],
+        }],
+    }, args.dry_run)
+
+    # Tags
+    print("\nTags:")
+    upsert_tag(svc, workspace["path"], {
+        "name": "GA4 Configuration",
+        "type": "gaawc",  # Google Analytics: GA4 Configuration
+        "parameter": [
+            {"type": "template", "key": "measurementId", "value": GA4_MEASUREMENT_ID},
+            {"type": "boolean", "key": "sendPageView", "value": "true"},
+        ],
+        "firingTriggerId": [all_pages_trigger_id] if all_pages_trigger_id else [],
+        "consentSettings": {
+            "consentStatus": "needed",
+            "consentType": {
+                "type": "list",
+                "list": [
+                    {"type": "template", "value": "analytics_storage"},
+                ],
+            },
+        },
+    }, args.dry_run)
+
+    upsert_tag(svc, workspace["path"], {
+        "name": "GA4 Event — donate_click",
+        "type": "gaawe",
+        "parameter": [
+            {"type": "template", "key": "measurementId", "value": GA4_MEASUREMENT_ID},
+            {"type": "template", "key": "eventName", "value": "donate_click"},
+        ],
+        "firingTriggerId": [donate_click_trigger_id] if donate_click_trigger_id else [],
+        "consentSettings": {
+            "consentStatus": "needed",
+            "consentType": {
+                "type": "list",
+                "list": [{"type": "template", "value": "analytics_storage"}],
+            },
+        },
+    }, args.dry_run)
+
+    upsert_tag(svc, workspace["path"], {
+        "name": "GA4 Event — email_click",
+        "type": "gaawe",
+        "parameter": [
+            {"type": "template", "key": "measurementId", "value": GA4_MEASUREMENT_ID},
+            {"type": "template", "key": "eventName", "value": "email_click"},
+        ],
+        "firingTriggerId": [email_click_trigger_id] if email_click_trigger_id else [],
+    }, args.dry_run)
+
+    # Publish
+    if not args.dry_run:
+        version = svc.accounts().containers().workspaces().create_version(
+            path=workspace["path"],
+            body={"name": "API bootstrap", "notes": "Generated by bootstrap-gtm.py"},
+        ).execute()
+        v = version.get("containerVersion", {})
+        if v:
+            svc.accounts().containers().versions().publish(path=v["path"]).execute()
+            print(f"\nPublished version {v.get('containerVersionId', '?')}")
+        else:
+            print("\nNo changes to publish (workspace already in sync).")
+
+    print("\nDone.")
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/google/config.py
+++ b/scripts/google/config.py
@@ -1,0 +1,61 @@
+"""Shared config + auth for the bootstrap scripts.
+
+Values can come from environment variables (preferred) or fall back to known
+defaults below. The service-account key is always loaded from
+GOOGLE_APPLICATION_CREDENTIALS or the GOOGLE_SA_KEY env var (JSON contents).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from pathlib import Path
+
+# Known fixed IDs for The Crooked House (override via env if they change).
+SITE_URL = "https://thecrookedhouse.net"
+SITE_NAME = "The Crooked House"
+ACCOUNT_NAME = "The Crooked House"
+CONTAINER_NAME = "thecrookedhouse.net"
+
+GTM_CONTAINER_ID = os.environ.get("GTM_CONTAINER_ID", "GTM-5JV8JHCH")
+GA4_MEASUREMENT_ID = os.environ.get("GA4_MEASUREMENT_ID", "G-EDCGRNN40D")
+GA4_STREAM_ID = os.environ.get("GA4_STREAM_ID", "14886848587")
+# Property ID is numeric; not provided yet — discovered at runtime via the
+# Analytics Admin API if unset.
+GA4_PROPERTY_ID = os.environ.get("GA4_PROPERTY_ID")
+
+# Scopes — superset for both bootstrap scripts.
+SCOPES = [
+    "https://www.googleapis.com/auth/tagmanager.edit.containers",
+    "https://www.googleapis.com/auth/tagmanager.publish",
+    "https://www.googleapis.com/auth/tagmanager.manage.users",
+    "https://www.googleapis.com/auth/analytics.edit",
+    "https://www.googleapis.com/auth/analytics.manage.users",
+    "https://www.googleapis.com/auth/analytics.readonly",
+]
+
+
+def credentials():
+    """Build google-auth credentials from either GOOGLE_APPLICATION_CREDENTIALS
+    (path to JSON) or GOOGLE_SA_KEY (raw JSON contents, used in CI)."""
+    from google.oauth2 import service_account
+
+    inline_key = os.environ.get("GOOGLE_SA_KEY")
+    if inline_key:
+        info = json.loads(inline_key)
+        return service_account.Credentials.from_service_account_info(
+            info, scopes=SCOPES
+        )
+
+    key_path = os.environ.get("GOOGLE_APPLICATION_CREDENTIALS")
+    if key_path and Path(key_path).exists():
+        return service_account.Credentials.from_service_account_file(
+            key_path, scopes=SCOPES
+        )
+
+    raise RuntimeError(
+        "No service-account credentials found. Set either "
+        "GOOGLE_APPLICATION_CREDENTIALS (file path) or GOOGLE_SA_KEY "
+        "(JSON contents)."
+    )

--- a/scripts/google/requirements.txt
+++ b/scripts/google/requirements.txt
@@ -1,0 +1,4 @@
+google-api-python-client>=2.130.0
+google-auth>=2.30.0
+google-analytics-admin>=0.22.0
+google-analytics-data>=0.18.0

--- a/scripts/google/wire-site.py
+++ b/scripts/google/wire-site.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+"""Patch the static site to load the GTM container instead of direct gtag/js.
+
+What this changes:
+
+  1. Adds the GTM container snippet to the <head> of every content page +
+     cookie-policy.html + 404.html (just before </head>, after the existing
+     CSP meta).
+  2. Adds the matching <noscript> iframe fallback immediately after <body>.
+  3. Updates cookie-consent.js to STOP loading gtag/js directly and instead
+     emit the GTM consent-mode v2 dataLayer calls (default + update events
+     when user accepts/declines categories).
+
+Re-running is safe — the script looks for an already-inserted GTM_CONTAINER_ID
+marker and skips files that have it.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+from config import GTM_CONTAINER_ID
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+PAGES = [
+    "index.html",
+    "donors/index.html",
+    "press/index.html",
+    "become-a-friend/index.html",
+    "cookie-policy.html",
+    "404.html",
+]
+
+
+def gtm_head_snippet() -> str:
+    """The official GTM <head> snippet with consent-mode v2 defaults applied
+    BEFORE the container loads."""
+    return f"""<!-- Google Tag Manager (consent-mode v2 default applied first) -->
+<script>
+window.dataLayer = window.dataLayer || [];
+function gtag(){{dataLayer.push(arguments);}}
+gtag('consent', 'default', {{
+  'ad_storage': 'denied',
+  'ad_user_data': 'denied',
+  'ad_personalization': 'denied',
+  'analytics_storage': 'denied',
+  'functionality_storage': 'granted',
+  'security_storage': 'granted',
+  'wait_for_update': 500
+}});
+(function(w,d,s,l,i){{w[l]=w[l]||[];w[l].push({{'gtm.start':
+new Date().getTime(),event:'gtm.js'}});var f=d.getElementsByTagName(s)[0],
+j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+}})(window,document,'script','dataLayer','{GTM_CONTAINER_ID}');
+</script>
+<!-- End Google Tag Manager -->"""
+
+
+def gtm_body_noscript() -> str:
+    return f"""<!-- Google Tag Manager (noscript) -->
+<noscript><iframe src="https://www.googletagmanager.com/ns.html?id={GTM_CONTAINER_ID}"
+height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+<!-- End Google Tag Manager (noscript) -->"""
+
+
+def patch_page(path: Path, dry_run: bool) -> bool:
+    """Returns True if file was changed."""
+    text = path.read_text(encoding="utf-8")
+    if GTM_CONTAINER_ID in text:
+        print(f"  {path.relative_to(REPO_ROOT)}: GTM already present, skipping")
+        return False
+
+    head_snippet = gtm_head_snippet()
+    body_snippet = gtm_body_noscript()
+
+    # Insert head snippet after the CSP meta tag (or before </head> if no CSP)
+    csp_re = re.compile(r"(<meta http-equiv=[\"']?content-security-policy[\"']?[^>]*>)",
+                        re.IGNORECASE)
+    if csp_re.search(text):
+        text = csp_re.sub(r"\1" + head_snippet, text, count=1)
+    else:
+        head_close_re = re.compile(r"(</head\s*>)", re.IGNORECASE)
+        if head_close_re.search(text):
+            text = head_close_re.sub(head_snippet + r"\1", text, count=1)
+        else:
+            # Fallback: insert right before <body
+            body_re = re.compile(r"(<body\b)", re.IGNORECASE)
+            text = body_re.sub(head_snippet + r"\1", text, count=1)
+
+    # Insert noscript iframe immediately after <body...>
+    body_open_re = re.compile(r"(<body\b[^>]*>)", re.IGNORECASE)
+    text = body_open_re.sub(r"\1" + body_snippet, text, count=1)
+
+    if dry_run:
+        print(f"  {path.relative_to(REPO_ROOT)}: WOULD PATCH (head + body)")
+        return True
+
+    path.write_text(text, encoding="utf-8")
+    print(f"  {path.relative_to(REPO_ROOT)}: patched (head + body)")
+    return True
+
+
+def patch_cookie_consent_js(dry_run: bool) -> bool:
+    """Replace the direct gtag/js loading with consent-mode v2 dataLayer
+    updates that GTM's container reacts to."""
+    js_path = REPO_ROOT / "cookie-consent.js"
+    if not js_path.exists():
+        print("  cookie-consent.js not found, skipping")
+        return False
+    text = js_path.read_text(encoding="utf-8")
+    if "// GTM consent-mode v2 wired" in text:
+        print("  cookie-consent.js: already wired for GTM consent mode, skipping")
+        return False
+    # We DON'T strip the existing GA-loading code in this scaffolding pass —
+    # instead we add the consent-mode update calls and let the GTM container
+    # handle the actual GA load. The legacy code is short-circuited because
+    # CONFIG.GA_MEASUREMENT_ID will be left as the placeholder.
+    # A follow-up PR can fully remove the gtag-loading code.
+    addition = """
+// GTM consent-mode v2 wired
+// Called by the cookie banner whenever the user updates their preferences.
+function pushConsentUpdate(consent) {
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('consent', 'update', {
+    'ad_storage': consent.marketing ? 'granted' : 'denied',
+    'ad_user_data': consent.marketing ? 'granted' : 'denied',
+    'ad_personalization': consent.marketing ? 'granted' : 'denied',
+    'analytics_storage': consent.analytics ? 'granted' : 'denied',
+    'functionality_storage': consent.functional ? 'granted' : 'denied',
+    'security_storage': 'granted'
+  });
+}
+"""
+    text = text.rstrip() + "\n" + addition + "\n"
+    if dry_run:
+        print("  cookie-consent.js: WOULD APPEND consent-update bridge")
+        return True
+    js_path.write_text(text, encoding="utf-8")
+    print("  cookie-consent.js: appended consent-update bridge")
+    return True
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--dry-run", action="store_true",
+                        help="Log planned changes without applying them.")
+    args = parser.parse_args()
+
+    print(f"=== wire-site (GTM={GTM_CONTAINER_ID}, dry-run={args.dry_run}) ===\n")
+
+    print("HTML pages:")
+    changed_pages = 0
+    for rel in PAGES:
+        p = REPO_ROOT / rel
+        if not p.exists():
+            print(f"  {rel}: NOT FOUND, skipping")
+            continue
+        if patch_page(p, args.dry_run):
+            changed_pages += 1
+
+    print("\nJS:")
+    js_changed = patch_cookie_consent_js(args.dry_run)
+
+    print(f"\nSummary: {changed_pages} page(s) patched, js wired = {js_changed}")
+    print("Don't forget: commit + PR + verify on the live site.")
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
Adds the code scaffolding for the API-driven Google integration. Everything is in place — once the GCP project + service account exist and four GitHub secrets are added, the workflow runs the bootstrap idempotently.

## What's in this PR
\`\`\`
scripts/google/
  README.md          — prereqs, secret names, how to run
  config.py          — shared auth + known IDs
  requirements.txt   — Python deps
  bootstrap-gtm.py   — GTM container config + consent mode v2 + tags
  bootstrap-ga4.py   — GA4 property config + retention + conversion events
  wire-site.py       — HTML patcher (adds GTM snippet to pages)
.github/workflows/google-setup.yml — manual-trigger workflow
\`\`\`

Known IDs baked in (overridable via env):
- GTM Container: \`GTM-5JV8JHCH\`
- GA4 Measurement: \`G-EDCGRNN40D\`
- GA4 Stream: \`14886848587\`

## What this PR does NOT do
The scripts can't run yet — needs four secrets added to the repo first:
- \`GOOGLE_SA_KEY\` — service account JSON contents
- \`GTM_CONTAINER_ID\`
- \`GA4_MEASUREMENT_ID\`
- \`GA4_PROPERTY_ID\` (or rely on auto-discovery)

These come from completing **issue #77** (GCP project + service account creation).

## How it'll be used after merge
1. Complete #77 — get a service account JSON
2. Add it as \`GOOGLE_SA_KEY\` repo secret
3. In Tag Manager UI + Analytics UI, add the SA email as a user (Admin / Editor)
4. Trigger workflow → choose \`bootstrap-gtm\` with dry-run ON → review output
5. Re-trigger with dry-run OFF → applies
6. Same for \`bootstrap-ga4\`
7. Trigger \`wire-site\` → opens a PR with HTML patches for review

## Test plan
- [ ] Workflow YAML syntax validates (\`act\` or push and let GitHub validate)
- [ ] Scripts importable: \`python -c "import bootstrap_gtm"\` (after pip install)
- [ ] Dry-run mode of all three works without raising

Refs #64 #67 #77