### PR TITLE
Switch IDs to env variables; bind workflow to google-prod environment

### DIFF
--- a/.github/workflows/google-setup.yml
+++ b/.github/workflows/google-setup.yml
@@ -18,15 +18,21 @@ on:
         default: true
         type: boolean
 
-# This workflow is manual-trigger only. It uses the FFC service-account JSON
-# stored as the GOOGLE_SA_KEY secret to call the Google APIs idempotently.
+# Manual-trigger workflow that runs the API automation against the
+# `google-prod` environment.
 #
-# Required secrets (Settings → Secrets and variables → Actions):
-#   GOOGLE_SA_KEY        Full contents of the service-account JSON key
-#   GTM_CONTAINER_ID     e.g. GTM-5JV8JHCH
-#   GA4_MEASUREMENT_ID   e.g. G-EDCGRNN40D
-#   GA4_STREAM_ID        e.g. 14886848587
-#   GA4_PROPERTY_ID      numeric, optional (discovered at runtime if unset)
+# The google-prod environment owns:
+#   VARIABLES (public, visible in logs):
+#     GTM_CONTAINER_ID     e.g. GTM-5JV8JHCH
+#     GA4_MEASUREMENT_ID   e.g. G-EDCGRNN40D
+#     GA4_STREAM_ID        e.g. 14886848587
+#     GCP_PROJECT_ID       e.g. charming-hour-496417-p9
+#   SECRETS (private, masked in logs):
+#     GOOGLE_SA_KEY        Full contents of the service-account JSON key
+#     GA4_PROPERTY_ID      Optional; auto-discovered if absent
+#
+# IDs are public information — they ship in the page HTML — so they belong
+# as variables, not secrets. The SA key is the only true secret.
 
 permissions:
   contents: write   # wire-site commits patched HTML
@@ -35,12 +41,14 @@ permissions:
 jobs:
   run:
     runs-on: ubuntu-latest
+    environment: google-prod
     env:
       GOOGLE_SA_KEY: ${{ secrets.GOOGLE_SA_KEY }}
-      GTM_CONTAINER_ID: ${{ secrets.GTM_CONTAINER_ID }}
-      GA4_MEASUREMENT_ID: ${{ secrets.GA4_MEASUREMENT_ID }}
-      GA4_STREAM_ID: ${{ secrets.GA4_STREAM_ID }}
+      GTM_CONTAINER_ID: ${{ vars.GTM_CONTAINER_ID }}
+      GA4_MEASUREMENT_ID: ${{ vars.GA4_MEASUREMENT_ID }}
+      GA4_STREAM_ID: ${{ vars.GA4_STREAM_ID }}
       GA4_PROPERTY_ID: ${{ secrets.GA4_PROPERTY_ID }}
+      GCP_PROJECT_ID: ${{ vars.GCP_PROJECT_ID }}
     steps:
       - uses: actions/checkout@v4
 
@@ -52,6 +60,14 @@ jobs:
 
       - name: Install dependencies
         run: pip install -r scripts/google/requirements.txt
+
+      - name: Show config (IDs only — SA key remains masked)
+        run: |
+          echo "GCP_PROJECT_ID:     $GCP_PROJECT_ID"
+          echo "GTM_CONTAINER_ID:   $GTM_CONTAINER_ID"
+          echo "GA4_MEASUREMENT_ID: $GA4_MEASUREMENT_ID"
+          echo "GA4_STREAM_ID:      $GA4_STREAM_ID"
+          echo "GA4_PROPERTY_ID:    ${GA4_PROPERTY_ID:-<unset; will auto-discover>}"
 
       - name: Run bootstrap-gtm.py
         if: ${{ inputs.script == 'bootstrap-gtm' || inputs.script == 'all' }}
@@ -77,7 +93,7 @@ jobs:
           title: 'Wire GTM container snippet into pages'
           commit-message: 'Wire GTM container snippet into pages'
           body: |
-            Automated: ran `scripts/google/wire-site.py` and patched HTML to load the GTM container `${{ env.GTM_CONTAINER_ID }}` plus the consent-mode v2 default state.
+            Automated: ran `scripts/google/wire-site.py` and patched HTML to load the GTM container `${{ vars.GTM_CONTAINER_ID }}` plus the consent-mode v2 default state.
 
             Trigger: workflow_dispatch on ${{ github.workflow }}.
           labels: integration,google-workspace

--- a/scripts/google/README.md
+++ b/scripts/google/README.md
@@ -45,15 +45,18 @@ Granted in the respective product UIs (not GCP):
 - **GTM**: in Tag Manager → Admin → User Management on the account → Add user → service account email → role: Admin
 - **GA4**: in Analytics → Admin → Property access management → Add user → service account email → role: Editor (or Administrator if needed)
 
-### 4. GitHub Actions secrets
-Required secrets on the repository (Settings → Secrets and variables → Actions):
+### 4. GitHub Actions environment
 
-| Secret | Value |
-|---|---|
-| `GOOGLE_SA_KEY` | The full contents of the service account JSON key file |
-| `GTM_CONTAINER_ID` | `GTM-5JV8JHCH` |
-| `GA4_PROPERTY_ID` | The numeric property ID, e.g. `123456789` (find in Analytics → Admin → Property settings) |
-| `GA4_MEASUREMENT_ID` | The `G-XXXXXXXXXX` ID from the Web data stream |
+The scripts run in the **`google-prod`** GitHub environment (Settings → Environments → google-prod). IDs are public — they ship in the page HTML — so they live as **variables** (visible in logs); only the SA key is a **secret**.
+
+| Type | Name | Value |
+|---|---|---|
+| variable | `GCP_PROJECT_ID` | `charming-hour-496417-p9` |
+| variable | `GTM_CONTAINER_ID` | `GTM-5JV8JHCH` |
+| variable | `GA4_MEASUREMENT_ID` | `G-EDCGRNN40D` |
+| variable | `GA4_STREAM_ID` | `14886848587` |
+| **secret** | `GOOGLE_SA_KEY` | full contents of the service-account JSON key file |
+| secret (optional) | `GA4_PROPERTY_ID` | numeric, e.g. `123456789` — auto-discovered if unset |
 
 ## How to run
 


### PR DESCRIPTION
## Summary
GTM/GA IDs are public information (they ship in the page HTML on every visit) — they belong as GitHub Actions **variables**, not secrets. Only the service-account JSON stays a secret.

Workflow now runs against the **\`google-prod\`** environment, which already owns:

| Type | Name | Value |
|---|---|---|
| variable | \`GCP_PROJECT_ID\` | \`charming-hour-496417-p9\` |
| variable | \`GTM_CONTAINER_ID\` | \`GTM-5JV8JHCH\` |
| variable | \`GA4_MEASUREMENT_ID\` | \`G-EDCGRNN40D\` |
| variable | \`GA4_STREAM_ID\` | \`14886848587\` |
| secret | \`GOOGLE_SA_KEY\` | _to be added_ (service-account JSON) |
| secret | \`GA4_PROPERTY_ID\` | _optional_ (auto-discovered if unset) |

Workflow also logs the IDs at runtime in a "Show config" step so auditors can see exactly which property is being modified.

## Test plan
- [ ] After merge, Settings → Environments → google-prod shows the 4 variables
- [ ] Trigger workflow with bootstrap-gtm + dry-run → "Show config" step prints the IDs, then fails gracefully because \`GOOGLE_SA_KEY\` isn't set yet