### PR TITLE
Switch GTM/GA auth to Workload Identity Federation (no JSON keys)

### DIFF
--- a/.github/workflows/google-setup.yml
+++ b/.github/workflows/google-setup.yml
@@ -21,20 +21,25 @@ on:
 # Manual-trigger workflow that runs the API automation against the
 # `google-prod` environment.
 #
-# The google-prod environment owns:
-#   VARIABLES (public, visible in logs):
-#     GTM_CONTAINER_ID     e.g. GTM-5JV8JHCH
-#     GA4_MEASUREMENT_ID   e.g. G-EDCGRNN40D
-#     GA4_STREAM_ID        e.g. 14886848587
-#     GCP_PROJECT_ID       e.g. charming-hour-496417-p9
-#   SECRETS (private, masked in logs):
-#     GOOGLE_SA_KEY        Full contents of the service-account JSON key
-#     GA4_PROPERTY_ID      Optional; auto-discovered if absent
+# AUTH: Workload Identity Federation (no JSON keys). GitHub mints a short-lived
+# OIDC token for the run; google-github-actions/auth@v2 exchanges it for a
+# Google access token bound to the `githubactions-thecrookedhouse` service
+# account. Token expires when the job ends — nothing to rotate, nothing to leak.
 #
-# IDs are public information — they ship in the page HTML — so they belong
-# as variables, not secrets. The SA key is the only true secret.
+# The google-prod environment owns:
+#   variables (visible in logs):
+#     GTM_CONTAINER_ID, GA4_MEASUREMENT_ID, GA4_STREAM_ID, GCP_PROJECT_ID,
+#     GOOGLE_SA_EMAIL, GOOGLE_SA_NAME, WIF_PROVIDER
+#   secrets (masked):
+#     GA4_PROPERTY_ID  — optional; auto-discovered if absent.
+#                        Marked secret only because some teams treat
+#                        property IDs as semi-private; safe to make a var.
+#
+# WIF_PROVIDER must be the full resource path:
+#   projects/<PROJECT_NUMBER>/locations/global/workloadIdentityPools/<POOL>/providers/<PROVIDER>
 
 permissions:
+  id-token: write   # WIF: GitHub mints the OIDC token
   contents: write   # wire-site commits patched HTML
   pull-requests: write
 
@@ -43,14 +48,21 @@ jobs:
     runs-on: ubuntu-latest
     environment: google-prod
     env:
-      GOOGLE_SA_KEY: ${{ secrets.GOOGLE_SA_KEY }}
+      GCP_PROJECT_ID: ${{ vars.GCP_PROJECT_ID }}
       GTM_CONTAINER_ID: ${{ vars.GTM_CONTAINER_ID }}
       GA4_MEASUREMENT_ID: ${{ vars.GA4_MEASUREMENT_ID }}
       GA4_STREAM_ID: ${{ vars.GA4_STREAM_ID }}
       GA4_PROPERTY_ID: ${{ secrets.GA4_PROPERTY_ID }}
-      GCP_PROJECT_ID: ${{ vars.GCP_PROJECT_ID }}
     steps:
       - uses: actions/checkout@v4
+
+      - id: auth
+        name: Authenticate to Google Cloud (Workload Identity Federation)
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ vars.WIF_PROVIDER }}
+          service_account: ${{ vars.GOOGLE_SA_EMAIL }}
+          project_id: ${{ vars.GCP_PROJECT_ID }}
 
       - uses: actions/setup-python@v5
         with:
@@ -61,13 +73,14 @@ jobs:
       - name: Install dependencies
         run: pip install -r scripts/google/requirements.txt
 
-      - name: Show config (IDs only — SA key remains masked)
+      - name: Show config (IDs only — auth is via WIF, no keys to print)
         run: |
           echo "GCP_PROJECT_ID:     $GCP_PROJECT_ID"
           echo "GTM_CONTAINER_ID:   $GTM_CONTAINER_ID"
           echo "GA4_MEASUREMENT_ID: $GA4_MEASUREMENT_ID"
           echo "GA4_STREAM_ID:      $GA4_STREAM_ID"
           echo "GA4_PROPERTY_ID:    ${GA4_PROPERTY_ID:-<unset; will auto-discover>}"
+          echo "Acting-as SA:       ${{ vars.GOOGLE_SA_EMAIL }}"
 
       - name: Run bootstrap-gtm.py
         if: ${{ inputs.script == 'bootstrap-gtm' || inputs.script == 'all' }}

--- a/scripts/google/README.md
+++ b/scripts/google/README.md
@@ -32,22 +32,62 @@ See [issue #77](https://github.com/FreeForCharity/FFC-EX-thecrookedhouse.net/iss
 - Google Analytics Data API
 
 ### 2. Service account
-Created in GCP console under `thecrookedhouse` project:
+Created in GCP console under the `charming-hour-496417-p9` project:
 
-- Name: `ffc-automation`
-- Email: `ffc-automation@thecrookedhouse.iam.gserviceaccount.com` (example)
-- Roles: none at project level
-- Key: JSON, downloaded once
+- Name: `githubactions-thecrookedhouse`
+- Email: `githubactions-thecrookedhouse@charming-hour-496417-p9.iam.gserviceaccount.com`
+- Roles at project level: none (we grant per-product in the UIs)
+- **No JSON key needed** — we use Workload Identity Federation instead.
 
-### 3. Service account permissions
-Granted in the respective product UIs (not GCP):
+### 3. Workload Identity Federation (auth without JSON keys)
 
-- **GTM**: in Tag Manager → Admin → User Management on the account → Add user → service account email → role: Admin
-- **GA4**: in Analytics → Admin → Property access management → Add user → service account email → role: Editor (or Administrator if needed)
+WIF lets GitHub Actions impersonate the service account with a short-lived OIDC token instead of a long-lived JSON key — Google's recommended pattern.
 
-### 4. GitHub Actions environment
+One-time setup in GCP:
 
-The scripts run in the **`google-prod`** GitHub environment (Settings → Environments → google-prod). IDs are public — they ship in the page HTML — so they live as **variables** (visible in logs); only the SA key is a **secret**.
+```bash
+# 1. Create the workload identity pool (free)
+gcloud iam workload-identity-pools create github-actions \
+  --project=charming-hour-496417-p9 \
+  --location=global \
+  --display-name="GitHub Actions"
+
+# 2. Create the GitHub OIDC provider in that pool
+gcloud iam workload-identity-pools providers create-oidc github-provider \
+  --project=charming-hour-496417-p9 \
+  --location=global \
+  --workload-identity-pool=github-actions \
+  --display-name="GitHub Actions Provider" \
+  --attribute-mapping="google.subject=assertion.sub,attribute.actor=assertion.actor,attribute.repository=assertion.repository,attribute.repository_owner=assertion.repository_owner" \
+  --attribute-condition="assertion.repository_owner == 'FreeForCharity'" \
+  --issuer-uri="https://token.actions.githubusercontent.com"
+
+# 3. Allow the GitHub repo to impersonate the service account
+gcloud iam service-accounts add-iam-policy-binding \
+  githubactions-thecrookedhouse@charming-hour-496417-p9.iam.gserviceaccount.com \
+  --project=charming-hour-496417-p9 \
+  --role=roles/iam.workloadIdentityUser \
+  --member="principalSet://iam.googleapis.com/projects/<PROJECT_NUMBER>/locations/global/workloadIdentityPools/github-actions/attribute.repository/FreeForCharity/FFC-EX-thecrookedhouse.net"
+```
+
+Get the project number for the last command:
+```bash
+gcloud projects describe charming-hour-496417-p9 --format='value(projectNumber)'
+```
+
+The full WIF provider path you'll need for the `WIF_PROVIDER` env variable:
+```
+projects/<PROJECT_NUMBER>/locations/global/workloadIdentityPools/github-actions/providers/github-provider
+```
+
+### 4. Service account permissions (granted in product UIs, not GCP)
+
+- **GTM**: Tag Manager → Admin → User Management on the account → Add user → `githubactions-thecrookedhouse@charming-hour-496417-p9.iam.gserviceaccount.com` → role: **Admin**
+- **GA4**: Analytics → Admin → Property access management → Add user → same email → role: **Editor** (or Administrator)
+
+### 5. GitHub Actions environment
+
+The scripts run in the **`google-prod`** GitHub environment (Settings → Environments → google-prod). IDs are public — they ship in the page HTML — so they live as **variables** (visible in logs).
 
 | Type | Name | Value |
 |---|---|---|
@@ -55,8 +95,12 @@ The scripts run in the **`google-prod`** GitHub environment (Settings → Enviro
 | variable | `GTM_CONTAINER_ID` | `GTM-5JV8JHCH` |
 | variable | `GA4_MEASUREMENT_ID` | `G-EDCGRNN40D` |
 | variable | `GA4_STREAM_ID` | `14886848587` |
-| **secret** | `GOOGLE_SA_KEY` | full contents of the service-account JSON key file |
-| secret (optional) | `GA4_PROPERTY_ID` | numeric, e.g. `123456789` — auto-discovered if unset |
+| variable | `GOOGLE_SA_NAME` | `githubactions-thecrookedhouse` |
+| variable | `GOOGLE_SA_EMAIL` | `githubactions-thecrookedhouse@charming-hour-496417-p9.iam.gserviceaccount.com` |
+| variable | `WIF_PROVIDER` | full path from step 3 |
+| secret (optional) | `GA4_PROPERTY_ID` | numeric — auto-discovered if unset |
+
+**No `GOOGLE_SA_KEY` needed.** That's the whole point of WIF.
 
 ## How to run
 
@@ -68,11 +112,10 @@ python -m venv .venv
 source .venv/bin/activate   # or .venv\Scripts\activate on Windows
 pip install -r requirements.txt
 
-# Set env from a local .env file (not committed)
-export GOOGLE_APPLICATION_CREDENTIALS=/path/to/ffc-automation-key.json
-export GTM_CONTAINER_ID=GTM-5JV8JHCH
-export GA4_PROPERTY_ID=123456789
-export GA4_MEASUREMENT_ID=G-XXXXXXXXXX
+# Authenticate as your Google user via ADC (one-time per machine)
+gcloud auth application-default login
+
+# IDs default to baked-in values in config.py; override only if needed.
 
 python bootstrap-gtm.py --dry-run    # preview changes
 python bootstrap-gtm.py              # apply

--- a/scripts/google/config.py
+++ b/scripts/google/config.py
@@ -1,18 +1,23 @@
 """Shared config + auth for the bootstrap scripts.
 
-Values can come from environment variables (preferred) or fall back to known
-defaults below. The service-account key is always loaded from
-GOOGLE_APPLICATION_CREDENTIALS or the GOOGLE_SA_KEY env var (JSON contents).
+Authentication uses **Application Default Credentials (ADC)**, which works
+transparently in three contexts:
+
+  1. GitHub Actions via Workload Identity Federation
+     (no JSON key; google-github-actions/auth@v2 sets up ADC for us).
+  2. Local development after `gcloud auth application-default login`.
+  3. Legacy: a service-account JSON file path in
+     GOOGLE_APPLICATION_CREDENTIALS, if you ever need that fallback.
+
+This is the Google-recommended pattern. We deliberately do NOT consume a
+JSON key passed via env var — that would defeat the whole point of WIF.
 """
 
 from __future__ import annotations
 
-import json
 import os
-import tempfile
-from pathlib import Path
 
-# Known fixed IDs for The Crooked House (override via env if they change).
+# Known fixed identifiers for The Crooked House (override via env if they change).
 SITE_URL = "https://thecrookedhouse.net"
 SITE_NAME = "The Crooked House"
 ACCOUNT_NAME = "The Crooked House"
@@ -21,11 +26,11 @@ CONTAINER_NAME = "thecrookedhouse.net"
 GTM_CONTAINER_ID = os.environ.get("GTM_CONTAINER_ID", "GTM-5JV8JHCH")
 GA4_MEASUREMENT_ID = os.environ.get("GA4_MEASUREMENT_ID", "G-EDCGRNN40D")
 GA4_STREAM_ID = os.environ.get("GA4_STREAM_ID", "14886848587")
+GCP_PROJECT_ID = os.environ.get("GCP_PROJECT_ID", "charming-hour-496417-p9")
 # Property ID is numeric; not provided yet — discovered at runtime via the
 # Analytics Admin API if unset.
 GA4_PROPERTY_ID = os.environ.get("GA4_PROPERTY_ID")
 
-# Scopes — superset for both bootstrap scripts.
 SCOPES = [
     "https://www.googleapis.com/auth/tagmanager.edit.containers",
     "https://www.googleapis.com/auth/tagmanager.publish",
@@ -37,25 +42,21 @@ SCOPES = [
 
 
 def credentials():
-    """Build google-auth credentials from either GOOGLE_APPLICATION_CREDENTIALS
-    (path to JSON) or GOOGLE_SA_KEY (raw JSON contents, used in CI)."""
-    from google.oauth2 import service_account
+    """Resolve Application Default Credentials and scope them.
 
-    inline_key = os.environ.get("GOOGLE_SA_KEY")
-    if inline_key:
-        info = json.loads(inline_key)
-        return service_account.Credentials.from_service_account_info(
-            info, scopes=SCOPES
-        )
+    Order of resolution (handled by google.auth.default):
+      1. GOOGLE_APPLICATION_CREDENTIALS env var (file path, optional)
+      2. WIF / external account credentials set up by gcloud or
+         google-github-actions/auth@v2
+      3. gcloud user credentials (from `gcloud auth application-default login`)
+      4. GCE / Cloud Run metadata server
+    """
+    import google.auth
 
-    key_path = os.environ.get("GOOGLE_APPLICATION_CREDENTIALS")
-    if key_path and Path(key_path).exists():
-        return service_account.Credentials.from_service_account_file(
-            key_path, scopes=SCOPES
-        )
-
-    raise RuntimeError(
-        "No service-account credentials found. Set either "
-        "GOOGLE_APPLICATION_CREDENTIALS (file path) or GOOGLE_SA_KEY "
-        "(JSON contents)."
-    )
+    creds, project = google.auth.default(scopes=SCOPES)
+    if project and project != GCP_PROJECT_ID:
+        # Don't fail — just note the mismatch for debugging.
+        import sys
+        print(f"note: ADC project ({project}) differs from configured "
+              f"GCP_PROJECT_ID ({GCP_PROJECT_ID})", file=sys.stderr)
+    return creds


### PR DESCRIPTION
## Summary
GCP recommended switching off long-lived JSON keys in favor of **Workload Identity Federation**. WIF mints a short-lived OIDC token per workflow run; nothing to rotate, nothing to leak. Cost: \$0.

## Changes
- **config.py** uses \`google.auth.default()\` (Application Default Credentials). Works with WIF in CI, \`gcloud auth application-default login\` locally, or a JSON key path as a fallback.
- **Workflow** uses \`google-github-actions/auth@v2\` with \`workload_identity_provider\` + \`service_account\` inputs, plus \`permissions: id-token: write\`. No \`GOOGLE_SA_KEY\` secret consumed.
- **README** has the three \`gcloud\` commands needed to create the WIF pool + OIDC provider + IAM policy binding, restricted to \`repository_owner == 'FreeForCharity'\` so only this org's repos can impersonate the SA.
- Issue **#77** updated with the same setup commands as a comment.

## Environment state (already applied)
\`google-prod\` environment has 7 variables now:
\`\`\`
GCP_PROJECT_ID      = charming-hour-496417-p9
GTM_CONTAINER_ID    = GTM-5JV8JHCH
GA4_MEASUREMENT_ID  = G-EDCGRNN40D
GA4_STREAM_ID       = 14886848587
GOOGLE_SA_NAME      = githubactions-thecrookedhouse
GOOGLE_SA_EMAIL     = githubactions-thecrookedhouse@charming-hour-496417-p9.iam.gserviceaccount.com
WIF_PROVIDER        = TODO_FILL_AFTER_WIF_SETUP
\`\`\`

## Still needed before workflow can fire
1. Run the three \`gcloud\` commands from #77 to create the WIF pool / provider / IAM binding
2. Update the \`WIF_PROVIDER\` variable with the real full path
3. Enable Tag Manager API + Analytics Admin API + Analytics Data API on the GCP project
4. Add the SA email as a user in Tag Manager (Admin) and Analytics (Editor)