### PR TITLE
Add bootstrap-sa-access.py + FFC OAuth-client pattern doc

### DIFF
--- a/scripts/google/FFC-OAUTH-CLIENT-PATTERN.md
+++ b/scripts/google/FFC-OAUTH-CLIENT-PATTERN.md
@@ -1,0 +1,69 @@
+# FFC pattern: bootstrapping service-account access to Google products
+
+A recurring problem across FFC sites: **GTM and GA's user-management UIs reject service account emails** ("This email doesn't match a Google Account"). The product APIs accept SA emails fine, but the required scopes (`tagmanager.manage.users`, `analytics.manage.users`) aren't in gcloud's whitelisted set.
+
+The fix below is the canonical FFC pattern. Use it on every new site.
+
+## One-time per FFC-managed GCP project
+
+### 1. Configure the OAuth consent screen (if not already done)
+
+1. <https://console.cloud.google.com/apis/credentials/consent> → select the project
+2. User Type: **Internal** (the project is in a Workspace org → internal-only is fine)
+3. App information:
+   - App name: `FFC API Admin`
+   - User support email: the project owner's Workspace email
+   - Developer contact: same
+4. Scopes: skip (we'll request specific scopes at OAuth flow time)
+5. Save and continue
+
+### 2. Create the OAuth client
+
+1. <https://console.cloud.google.com/apis/credentials> → select the project
+2. **+ CREATE CREDENTIALS** → **OAuth client ID**
+3. Application type: **Desktop app**
+4. Name: `FFC API Admin (local)`
+5. Click **Create**
+6. **Download JSON** from the popup — save it as `client_secret_ffc-api-admin.json`
+
+> ⚠️ Despite the name, "client secrets" for Desktop OAuth apps are **not real secrets**; Google's docs explicitly note this. They can't be exfiltrated to do harm because Google still requires user consent in a browser. But still keep the file out of git.
+
+### 3. Run the bootstrap script
+
+```bash
+cd scripts/google
+pip install -r requirements.txt
+
+python bootstrap-sa-access.py \
+  --client-secrets ~/Downloads/client_secret_ffc-api-admin.json \
+  --sa-email <SA_EMAIL> \
+  --gtm-account "<GTM_ACCOUNT_NAME>" \
+  --ga4-measurement-id <G-XXXXXXXXXX> \
+  --gtm-role admin \
+  --ga4-role editor
+```
+
+The first run opens a browser. Sign in as a user who is **Admin on the GTM account** and **Administrator on the GA4 property**, click **Allow**. A refresh token is cached at `~/.config/ffc-google/token.json` — subsequent runs don't need the browser.
+
+The script is idempotent. Re-running reports "already granted" for anything already configured.
+
+## When to re-run
+
+- New service account that needs API access on a product → run the script with that SA
+- Re-rotating the OAuth refresh token → delete `~/.config/ffc-google/token.json` and re-run
+
+## When NOT to use this
+
+For granting **human user** access — that works fine in the GTM and GA UIs. Use the UIs for people; reserve this script for service accounts.
+
+## FFC-wide reuse
+
+This OAuth client lives in the project's own GCP space. If FFC wants a single shared OAuth client across all sites, host it in a dedicated `ffc-shared` GCP project; the client_secrets JSON then becomes a shared FFC artifact rather than per-site.
+
+## Per-site usage
+
+| Site | SA email | GTM account | GA4 measurement | Bootstrap command |
+|---|---|---|---|---|
+| thecrookedhouse.net | `githubactions-thecrookedhouse@charming-hour-496417-p9.iam.gserviceaccount.com` | "The Crooked House" | `G-EDCGRNN40D` | see above |
+
+Add a row for each new FFC site as it's onboarded.

--- a/scripts/google/bootstrap-sa-access.py
+++ b/scripts/google/bootstrap-sa-access.py
@@ -1,0 +1,243 @@
+#!/usr/bin/env python3
+"""One-time bootstrap: grant a service account access to GTM + GA4 + (later)
+Search Console via API, bypassing the UIs that reject SA emails as
+"not a Google Account".
+
+Why this script exists:
+  - GTM and GA's user-management UIs validate that the email looks like a
+    "real" Google user account and reject *.iam.gserviceaccount.com addresses.
+  - The APIs accept SA emails fine, but the required user-management scopes
+    (tagmanager.manage.users, analytics.manage.users) are NOT in gcloud's
+    default OAuth client's whitelist.
+  - So we bring our own OAuth client, run an InstalledAppFlow once to get a
+    refresh token with the broader scopes, and call the APIs ourselves.
+
+This is meant to be a **reusable FFC-wide tool**. The same pattern works for
+any FFC site that needs to bootstrap SA access to Google products. See
+docs/ffc-google-sa-bootstrap.md.
+
+Usage:
+
+  # First time (or re-auth):
+  python bootstrap-sa-access.py \
+      --client-secrets ~/Downloads/client_secret_xxx.json \
+      --sa-email githubactions-thecrookedhouse@charming-hour-496417-p9.iam.gserviceaccount.com \
+      --gtm-account "The Crooked House" \
+      --ga4-measurement-id G-EDCGRNN40D \
+      --gtm-role admin --ga4-role editor
+
+  # Re-runs use the cached refresh token at ~/.config/ffc-google/token.json.
+
+Idempotent: if the SA already has the desired role, the script reports
+"already granted" and exits cleanly.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+
+# These imports are lazy where possible to keep --help fast.
+try:
+    from google.oauth2.credentials import Credentials
+    from google_auth_oauthlib.flow import InstalledAppFlow
+    from google.auth.transport.requests import Request
+    from googleapiclient.discovery import build
+except ImportError:
+    sys.exit(
+        "Missing dependencies. Run: pip install -r requirements.txt"
+    )
+
+SCOPES = [
+    "https://www.googleapis.com/auth/tagmanager.manage.users",
+    "https://www.googleapis.com/auth/tagmanager.edit.containers",
+    "https://www.googleapis.com/auth/analytics.manage.users",
+    "https://www.googleapis.com/auth/analytics.edit",
+    "https://www.googleapis.com/auth/analytics.readonly",
+]
+
+TOKEN_DIR = Path.home() / ".config" / "ffc-google"
+TOKEN_PATH = TOKEN_DIR / "token.json"
+
+
+def get_creds(client_secrets_path: Path) -> Credentials:
+    """Load cached credentials or run the OAuth flow."""
+    creds = None
+    if TOKEN_PATH.exists():
+        creds = Credentials.from_authorized_user_file(str(TOKEN_PATH), SCOPES)
+    if creds and creds.expired and creds.refresh_token:
+        creds.refresh(Request())
+    elif not creds or not creds.valid:
+        flow = InstalledAppFlow.from_client_secrets_file(
+            str(client_secrets_path), SCOPES
+        )
+        # Try a local server first; fall back to manual code paste.
+        try:
+            creds = flow.run_local_server(port=0, prompt="consent")
+        except Exception:
+            creds = flow.run_console()
+        TOKEN_DIR.mkdir(parents=True, exist_ok=True)
+        TOKEN_PATH.write_text(creds.to_json())
+        print(f"Cached refresh token to {TOKEN_PATH}")
+    return creds
+
+
+# ---------- GTM ----------
+
+GTM_ROLE_MAP = {"admin": "admin", "edit": "user"}
+
+
+def grant_gtm(creds, sa_email: str, account_name: str, role: str) -> None:
+    print(f"\n--- GTM: grant {sa_email} as {role} on '{account_name}' ---")
+    svc = build("tagmanager", "v2", credentials=creds, cache_discovery=False)
+    accounts = svc.accounts().list().execute().get("account", [])
+    account = next((a for a in accounts if a.get("name") == account_name), None)
+    if not account and len(accounts) == 1:
+        account = accounts[0]
+        print(f"  using only available account: {account.get('name')}")
+    if not account:
+        sys.exit(
+            f"No GTM account named {account_name!r}. Found: "
+            f"{[a.get('name') for a in accounts]}"
+        )
+
+    # Check whether SA is already a user.
+    perms = svc.accounts().user_permissions().list(parent=account["path"]).execute()
+    existing = next(
+        (p for p in perms.get("userPermission", [])
+         if p.get("emailAddress", "").lower() == sa_email.lower()),
+        None,
+    )
+    target_perm = GTM_ROLE_MAP[role]
+    if existing:
+        current = existing.get("accountAccess", {}).get("permission")
+        if current == target_perm:
+            print(f"  already granted ({current}). Done.")
+            return
+        print(f"  updating: {current} -> {target_perm}")
+        svc.accounts().user_permissions().update(
+            path=existing["path"],
+            body={
+                "emailAddress": existing["emailAddress"],
+                "accountAccess": {"permission": target_perm},
+                "containerAccess": existing.get("containerAccess", []),
+            },
+        ).execute()
+    else:
+        print(f"  inviting as {target_perm}")
+        svc.accounts().user_permissions().create(
+            parent=account["path"],
+            body={
+                "emailAddress": sa_email,
+                "accountAccess": {"permission": target_perm},
+            },
+        ).execute()
+    print("  done.")
+
+
+# ---------- GA4 ----------
+
+GA4_ROLE_MAP = {
+    "admin": "predefinedRoles/admin",
+    "editor": "predefinedRoles/edit",
+    "viewer": "predefinedRoles/read",
+}
+
+
+def grant_ga4(creds, sa_email: str, measurement_id: str, role: str) -> None:
+    print(f"\n--- GA4: grant {sa_email} as {role} on property w/ measurement {measurement_id} ---")
+    from google.analytics.admin import AnalyticsAdminServiceClient
+    from google.analytics.admin_v1beta.types import (
+        AccessBinding,
+        CreateAccessBindingRequest,
+    )
+
+    client = AnalyticsAdminServiceClient(credentials=creds)
+    property_path = None
+    for account_summary in client.list_account_summaries():
+        for prop in account_summary.property_summaries:
+            try:
+                streams = client.list_data_streams(parent=prop.property)
+            except Exception:
+                continue
+            for stream in streams:
+                wsd = getattr(stream, "web_stream_data", None)
+                if wsd and wsd.measurement_id == measurement_id:
+                    property_path = prop.property
+                    print(f"  property: {property_path} ({prop.display_name})")
+                    break
+            if property_path:
+                break
+        if property_path:
+            break
+    if not property_path:
+        sys.exit(f"No GA4 property has a web stream with measurement_id={measurement_id}")
+
+    target_role = GA4_ROLE_MAP[role]
+    bindings = client.list_access_bindings(parent=property_path)
+    for b in bindings:
+        if (getattr(b, "user", "") or "").lower() == sa_email.lower():
+            if target_role in list(b.roles):
+                print(f"  already granted ({target_role}). Done.")
+                return
+            print(f"  updating roles: {list(b.roles)} -> [{target_role}]")
+            b.roles[:] = [target_role]
+            from google.analytics.admin_v1beta.types import UpdateAccessBindingRequest
+            client.update_access_binding(
+                request=UpdateAccessBindingRequest(access_binding=b)
+            )
+            print("  done.")
+            return
+
+    print(f"  inviting as {target_role}")
+    client.create_access_binding(
+        request=CreateAccessBindingRequest(
+            parent=property_path,
+            access_binding=AccessBinding(user=sa_email, roles=[target_role]),
+        )
+    )
+    print("  done.")
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
+    parser.add_argument("--client-secrets", required=True, type=Path,
+                        help="Path to OAuth client_secret_*.json downloaded from "
+                             "console.cloud.google.com/apis/credentials")
+    parser.add_argument("--sa-email", required=True,
+                        help="Service account email to grant access to.")
+    parser.add_argument("--gtm-account", default=None,
+                        help="GTM account name (if multiple). Skip GTM grant if omitted.")
+    parser.add_argument("--gtm-role", default="admin", choices=["admin", "edit"],
+                        help="GTM role for the SA (default: admin).")
+    parser.add_argument("--ga4-measurement-id", default=None,
+                        help="GA4 measurement ID (G-XXXXXXXXXX). Skip GA4 grant if omitted.")
+    parser.add_argument("--ga4-role", default="editor",
+                        choices=["admin", "editor", "viewer"],
+                        help="GA4 role for the SA (default: editor).")
+    args = parser.parse_args()
+
+    if not args.client_secrets.exists():
+        sys.exit(f"client-secrets file not found: {args.client_secrets}")
+
+    print(f"Granting access for SA: {args.sa_email}")
+    creds = get_creds(args.client_secrets)
+
+    if args.gtm_account:
+        grant_gtm(creds, args.sa_email, args.gtm_account, args.gtm_role)
+    else:
+        print("\n(Skipping GTM — no --gtm-account specified.)")
+
+    if args.ga4_measurement_id:
+        grant_ga4(creds, args.sa_email, args.ga4_measurement_id, args.ga4_role)
+    else:
+        print("\n(Skipping GA4 — no --ga4-measurement-id specified.)")
+
+    print("\nAll done.")
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/google/requirements.txt
+++ b/scripts/google/requirements.txt
@@ -1,4 +1,5 @@
 google-api-python-client>=2.130.0
 google-auth>=2.30.0
+google-auth-oauthlib>=1.2.0
 google-analytics-admin>=0.22.0
 google-analytics-data>=0.18.0


### PR DESCRIPTION
## Summary
Solves the recurring FFC problem of GTM/GA UIs rejecting service-account emails ("This email doesn't match a Google Account"). The UIs validate emails as "real" Google user accounts and reject \`*.iam.gserviceaccount.com\` addresses. The APIs accept them fine, but the user-management scopes need an OAuth client beyond gcloud's whitelisted set.

## Adds
- \`scripts/google/bootstrap-sa-access.py\` — runs an InstalledAppFlow OAuth dance with a Desktop-app OAuth client. Caches refresh token at \`~/.config/ffc-google/token.json\`. Idempotent grants for both GTM and GA4 in one invocation.
- \`scripts/google/FFC-OAUTH-CLIENT-PATTERN.md\` — documents the consent-screen + OAuth-client creation flow so any FFC site can follow the same path. Includes a "Per-site usage" table to track which sites have been bootstrapped.

## Test plan
- [ ] Create the OAuth client in GCP per the doc
- [ ] Download client_secret JSON
- [ ] Run \`python bootstrap-sa-access.py --client-secrets ... --sa-email githubactions-thecrookedhouse@charming-hour-496417-p9.iam.gserviceaccount.com --gtm-account "The Crooked House" --ga4-measurement-id G-EDCGRNN40D\`
- [ ] Sign in as clarkemoyer@thecrookedhouse.net in the browser, click Allow
- [ ] Re-run; should report "already granted" for both products