### PR TITLE
Fix GA4 admin: use v1alpha + correct role names + FFC token fallback

### DIFF
--- a/scripts/google/bootstrap-ga4.py
+++ b/scripts/google/bootstrap-ga4.py
@@ -21,8 +21,8 @@ import argparse
 import os
 import sys
 
-from google.analytics.admin import AnalyticsAdminServiceClient
-from google.analytics.admin_v1beta.types import (
+from google.analytics.admin_v1alpha import AnalyticsAdminServiceClient
+from google.analytics.admin_v1alpha.types import (
     ConversionEvent,
     CustomDimension,
     DataRetentionSettings,

--- a/scripts/google/bootstrap-sa-access.py
+++ b/scripts/google/bootstrap-sa-access.py
@@ -142,15 +142,15 @@ def grant_gtm(creds, sa_email: str, account_name: str, role: str) -> None:
 
 GA4_ROLE_MAP = {
     "admin": "predefinedRoles/admin",
-    "editor": "predefinedRoles/edit",
-    "viewer": "predefinedRoles/read",
+    "editor": "predefinedRoles/editor",
+    "viewer": "predefinedRoles/viewer",
 }
 
 
 def grant_ga4(creds, sa_email: str, measurement_id: str, role: str) -> None:
     print(f"\n--- GA4: grant {sa_email} as {role} on property w/ measurement {measurement_id} ---")
-    from google.analytics.admin import AnalyticsAdminServiceClient
-    from google.analytics.admin_v1beta.types import (
+    from google.analytics.admin_v1alpha import AnalyticsAdminServiceClient
+    from google.analytics.admin_v1alpha.types import (
         AccessBinding,
         CreateAccessBindingRequest,
     )
@@ -185,7 +185,7 @@ def grant_ga4(creds, sa_email: str, measurement_id: str, role: str) -> None:
                 return
             print(f"  updating roles: {list(b.roles)} -> [{target_role}]")
             b.roles[:] = [target_role]
-            from google.analytics.admin_v1beta.types import UpdateAccessBindingRequest
+            from google.analytics.admin_v1alpha.types import UpdateAccessBindingRequest
             client.update_access_binding(
                 request=UpdateAccessBindingRequest(access_binding=b)
             )

--- a/scripts/google/config.py
+++ b/scripts/google/config.py
@@ -42,20 +42,33 @@ SCOPES = [
 
 
 def credentials():
-    """Resolve Application Default Credentials and scope them.
+    """Resolve credentials, preferring the FFC OAuth refresh token if present.
 
-    Order of resolution (handled by google.auth.default):
-      1. GOOGLE_APPLICATION_CREDENTIALS env var (file path, optional)
-      2. WIF / external account credentials set up by gcloud or
+    Order of resolution:
+      1. ~/.config/ffc-google/token.json — refresh token from bootstrap-sa-access.py
+         (broader scopes than gcloud default; needed for user-management APIs)
+      2. GOOGLE_APPLICATION_CREDENTIALS env var (file path, optional)
+      3. WIF / external account credentials set up by gcloud or
          google-github-actions/auth@v2
-      3. gcloud user credentials (from `gcloud auth application-default login`)
-      4. GCE / Cloud Run metadata server
+      4. gcloud user credentials (from `gcloud auth application-default login`)
+      5. GCE / Cloud Run metadata server
     """
+    from pathlib import Path
+
+    ffc_token = Path.home() / ".config" / "ffc-google" / "token.json"
+    if ffc_token.exists():
+        from google.oauth2.credentials import Credentials
+        from google.auth.transport.requests import Request
+
+        creds = Credentials.from_authorized_user_file(str(ffc_token), SCOPES)
+        if creds.expired and creds.refresh_token:
+            creds.refresh(Request())
+        return creds
+
     import google.auth
 
     creds, project = google.auth.default(scopes=SCOPES)
     if project and project != GCP_PROJECT_ID:
-        # Don't fail — just note the mismatch for debugging.
         import sys
         print(f"note: ADC project ({project}) differs from configured "
               f"GCP_PROJECT_ID ({GCP_PROJECT_ID})", file=sys.stderr)

--- a/scripts/google/manage-users.py
+++ b/scripts/google/manage-users.py
@@ -24,12 +24,12 @@ from __future__ import annotations
 import argparse
 import sys
 
-from google.analytics.admin_v1beta.types import (
+from google.analytics.admin_v1alpha.types import (
     AccessBinding,
     CreateAccessBindingRequest,
     UpdateAccessBindingRequest,
 )
-from google.analytics.admin import AnalyticsAdminServiceClient
+from google.analytics.admin_v1alpha import AnalyticsAdminServiceClient
 from googleapiclient.discovery import build
 
 from config import ACCOUNT_NAME, GA4_MEASUREMENT_ID, GA4_PROPERTY_ID, credentials
@@ -117,8 +117,8 @@ def gtm_reconcile(svc, dry_run: bool, prune: bool) -> None:
 
 GA4_ROLE_MAP = {
     "admin": "predefinedRoles/admin",
-    "editor": "predefinedRoles/edit",
-    "viewer": "predefinedRoles/read",
+    "editor": "predefinedRoles/editor",
+    "viewer": "predefinedRoles/viewer",
 }
 
 


### PR DESCRIPTION
## Summary
Live-fire of the bootstrap script revealed three real bugs. Already proven working — used these fixes to grant both the GH Actions SA and clarkemoyer@freeforcharity.org access to GTM + GA4.

| Bug | Fix |
|---|---|
| \`AccessBinding\` imports from \`admin_v1beta.types\` (the v1beta module has no access bindings — IAM-based access management is v1alpha only) | Switched 3 files to \`admin_v1alpha\` |
| GA4 predefined role strings used abbreviated names (\`predefinedRoles/edit\`, \`predefinedRoles/read\`) | Use full English (\`predefinedRoles/editor\`, \`predefinedRoles/viewer\`) |
| Local scripts couldn't get user-management scopes from gcloud's default ADC (gcloud OAuth client is whitelisted for limited scopes) | \`config.credentials()\` now prefers \`~/.config/ffc-google/token.json\` if present (cached by bootstrap-sa-access.py's broader OAuth flow) before falling back to ADC. CI still uses WIF transparently. |

## Live verification
- \`bootstrap-sa-access.py\` granted the SA **Admin on GTM**, **Editor on GA4 property 538040467**
- \`manage-users.py\` granted clarkemoyer@freeforcharity.org the **same access**
- Both scripts re-runnable idempotently

## Bonus discovery
GA4 property ID = **538040467**. Pending GitHub API rate-limit reset to set as a variable in the google-prod environment.

Refs #64 #67 #77