### PR TITLE
Remove invalid waitForTags/checkValidation from trigger spec

### DIFF
--- a/scripts/google/bootstrap-gtm.py
+++ b/scripts/google/bootstrap-gtm.py
@@ -155,8 +155,6 @@ def main():
                  "value": r"(paypal\.com\/donate|zeffy\.com|donate\.thecrookedhouse\.net)"},
             ],
         }],
-        "waitForTags": [{"type": "boolean", "key": "boolean", "value": "true"}],
-        "checkValidation": [{"type": "boolean", "key": "boolean", "value": "false"}],
     }, args.dry_run)
 
     email_click_trigger_id = upsert_trigger(svc, workspace["path"], {


### PR DESCRIPTION
Live-fire fix: GTM API rejects waitForTags+checkValidation as arrays. They're single Parameter objects (and optional). Removed entirely.