### PR TITLE
Pass GTM/GA scopes through auth@v2

### DIFF
--- a/.github/workflows/google-setup.yml
+++ b/.github/workflows/google-setup.yml
@@ -64,6 +64,15 @@ jobs:
           workload_identity_provider: ${{ vars.WIF_PROVIDER }}
           service_account: ${{ vars.GOOGLE_SA_EMAIL }}
           project_id: ${{ vars.GCP_PROJECT_ID }}
+          token_format: access_token
+          access_token_scopes: |-
+            https://www.googleapis.com/auth/tagmanager.edit.containers
+            https://www.googleapis.com/auth/tagmanager.publish
+            https://www.googleapis.com/auth/tagmanager.manage.users
+            https://www.googleapis.com/auth/analytics.edit
+            https://www.googleapis.com/auth/analytics.manage.users
+            https://www.googleapis.com/auth/analytics.readonly
+            https://www.googleapis.com/auth/cloud-platform
 
       - uses: actions/setup-python@v5
         with:


### PR DESCRIPTION
create_version + access binding API calls require specific scopes; cloud-platform isn't enough. Adding access_token_scopes to the WIF auth step.