### PR TITLE
Add tagmanager.edit.containerversions scope

### DIFF
--- a/.github/workflows/google-setup.yml
+++ b/.github/workflows/google-setup.yml
@@ -67,6 +67,7 @@ jobs:
           token_format: access_token
           access_token_scopes: |-
             https://www.googleapis.com/auth/tagmanager.edit.containers
+            https://www.googleapis.com/auth/tagmanager.edit.containerversions
             https://www.googleapis.com/auth/tagmanager.publish
             https://www.googleapis.com/auth/tagmanager.manage.users
             https://www.googleapis.com/auth/analytics.edit

--- a/scripts/google/config.py
+++ b/scripts/google/config.py
@@ -33,6 +33,7 @@ GA4_PROPERTY_ID = os.environ.get("GA4_PROPERTY_ID")
 
 SCOPES = [
     "https://www.googleapis.com/auth/tagmanager.edit.containers",
+    "https://www.googleapis.com/auth/tagmanager.edit.containerversions",
     "https://www.googleapis.com/auth/tagmanager.publish",
     "https://www.googleapis.com/auth/tagmanager.manage.users",
     "https://www.googleapis.com/auth/analytics.edit",


### PR DESCRIPTION
create_version uses a different OAuth scope than the rest of the container content APIs. Adding it to both the workflow access_token_scopes and config.py SCOPES.