### PR TITLE
URGENT: Repoint broken PayPal Donate buttons to /become-a-friend/

### DIFF
--- a/404.html
+++ b/404.html
@@ -136,7 +136,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
       <p>The page you were looking for isn't here. It may have moved, or the link that brought you here might be off by a letter or two. Here's where to find what you need:</p>
       <div class="links">
         <a href="/">Home</a>
-        <a href="https://www.paypal.com/donate/?hosted_button_id=X4VGJ5VTWXVUN" class="secondary">Donate</a>
+        <a href="/become-a-friend/" class="secondary">Donate</a>
         <a href="/donors/" class="secondary">Donors</a>
         <a href="/become-a-friend/" class="secondary">Become a Friend</a>
         <a href="/press/" class="secondary">Press</a>

--- a/become-a-friend/index.html
+++ b/become-a-friend/index.html
@@ -85,7 +85,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
  <nav class="Header-nav Header-nav--primary" data-nc-element=primary-nav data-content-field=navigation>
  
  <div class=Header-nav-inner>
- <a href=https://thecrookedhouse.net/ class=Header-nav-item data-test=template-nav>Home</a><a href="https://www.paypal.com/donate/?hosted_button_id=X4VGJ5VTWXVUN" class=Header-nav-item>Donate</a><a href=https://thecrookedhouse.net/donors class=Header-nav-item data-test=template-nav>Donors</a><a href=https://thecrookedhouse.net/become-a-friend class="Header-nav-item Header-nav-item--active" data-test=template-nav>Become a Friend</a><a href=https://thecrookedhouse.net/press class=Header-nav-item data-test=template-nav>Press</a>
+ <a href=https://thecrookedhouse.net/ class=Header-nav-item data-test=template-nav>Home</a><a href="/become-a-friend/" class=Header-nav-item>Donate</a><a href=https://thecrookedhouse.net/donors class=Header-nav-item data-test=template-nav>Donors</a><a href=https://thecrookedhouse.net/become-a-friend class="Header-nav-item Header-nav-item--active" data-test=template-nav>Become a Friend</a><a href=https://thecrookedhouse.net/press class=Header-nav-item data-test=template-nav>Press</a>
  </div>
  </nav><nav class="Header-nav Header-nav--secondary" data-nc-element=secondary-nav data-content-field=navigation>
  
@@ -119,7 +119,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
  
 </div></div><div class="sqs-block website-component-block sqs-block-website-component sqs-block-button button-block" data-block-css='["https://definitions.sqspcdn.com/website-component-definition/static-assets/website.components.button/a6f7f01e-ebd3-4275-b223-83d5a4574151_124/website.components.button.styles.css"]' data-block-scripts='["https://definitions.sqspcdn.com/website-component-definition/static-assets/website.components.button/a6f7f01e-ebd3-4275-b223-83d5a4574151_124/website.components.button.visitor.js"]' data-block-type=1337 data-definition-name=website.components.button data-sqsp-block=button id=block-yui_3_17_2_3_1473345619906_15885><div class=sqs-block-content id=yui_3_17_2_1_1761695033349_88>
 <div class="sqs-block-button-container sqs-block-button-container--center" data-animation-role=button data-alignment=center data-button-size=medium data-button-type=primary id=yui_3_17_2_1_1761695033349_87> 
- <a href="https://www.paypal.com/donate/?hosted_button_id=X4VGJ5VTWXVUN" class="sqs-block-button-element--medium sqs-button-element--primary sqs-block-button-element" data-sqsp-button data-initialized=true>
+ <a href="/become-a-friend/" class="sqs-block-button-element--medium sqs-button-element--primary sqs-block-button-element" data-sqsp-button data-initialized=true>
  Donate to The Crooked House
  </a>
  <style class=sf-hidden>#block-yui_3_17_2_3_1473345619906_15885{--sqs-block-content-flex:0}</style>

--- a/donors/index.html
+++ b/donors/index.html
@@ -110,7 +110,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
  <nav class="Header-nav Header-nav--primary" data-nc-element=primary-nav data-content-field=navigation>
  
  <div class=Header-nav-inner>
- <a href=https://thecrookedhouse.net/ class=Header-nav-item data-test=template-nav>Home</a><a href="https://www.paypal.com/donate/?hosted_button_id=X4VGJ5VTWXVUN" class=Header-nav-item>Donate</a><a href=https://thecrookedhouse.net/donors class="Header-nav-item Header-nav-item--active" data-test=template-nav>Donors</a><a href=https://thecrookedhouse.net/become-a-friend class=Header-nav-item data-test=template-nav>Become a Friend</a><a href=https://thecrookedhouse.net/press class=Header-nav-item data-test=template-nav>Press</a>
+ <a href=https://thecrookedhouse.net/ class=Header-nav-item data-test=template-nav>Home</a><a href="/become-a-friend/" class=Header-nav-item>Donate</a><a href=https://thecrookedhouse.net/donors class="Header-nav-item Header-nav-item--active" data-test=template-nav>Donors</a><a href=https://thecrookedhouse.net/become-a-friend class=Header-nav-item data-test=template-nav>Become a Friend</a><a href=https://thecrookedhouse.net/press class=Header-nav-item data-test=template-nav>Press</a>
  </div>
  </nav><nav class="Header-nav Header-nav--secondary" data-nc-element=secondary-nav data-content-field=navigation>
  

--- a/index.html
+++ b/index.html
@@ -612,7 +612,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
  <nav class="Header-nav Header-nav--primary" data-nc-element=primary-nav data-content-field=navigation>
  
  <div class=Header-nav-inner>
- <a href=. class="Header-nav-item Header-nav-item--active" data-test=template-nav>Home</a><a href="https://www.paypal.com/donate/?hosted_button_id=X4VGJ5VTWXVUN" class=Header-nav-item>Donate</a><a href=donors class=Header-nav-item data-test=template-nav>Donors</a><a href=become-a-friend class=Header-nav-item data-test=template-nav>Become a Friend</a><a href=press class=Header-nav-item data-test=template-nav>Press</a>
+ <a href=. class="Header-nav-item Header-nav-item--active" data-test=template-nav>Home</a><a href="/become-a-friend/" class=Header-nav-item>Donate</a><a href=donors class=Header-nav-item data-test=template-nav>Donors</a><a href=become-a-friend class=Header-nav-item data-test=template-nav>Become a Friend</a><a href=press class=Header-nav-item data-test=template-nav>Press</a>
  </div>
  </nav><nav class="Header-nav Header-nav--secondary" data-nc-element=secondary-nav data-content-field=navigation>
  
@@ -1115,7 +1115,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
  
 </div></div><div class="sqs-block website-component-block sqs-block-website-component sqs-block-button button-block" data-block-css='["https://definitions.sqspcdn.com/website-component-definition/static-assets/website.components.button/459c1b3d-b839-4cbb-9c5f-5b98a9bc9535_122/website.components.button.styles.css"]' data-block-scripts='["https://definitions.sqspcdn.com/website-component-definition/static-assets/website.components.button/459c1b3d-b839-4cbb-9c5f-5b98a9bc9535_122/website.components.button.visitor.js"]' data-block-type=1337 data-definition-name=website.components.button data-sqsp-block=button id=block-yui_3_17_2_1_1729540697805_58139><div class=sqs-block-content id=yui_3_17_2_1_1761603656792_187>
 <div class="sqs-block-button-container sqs-block-button-container--center" data-animation-role=button data-alignment=center data-button-size=medium data-button-type=primary id=yui_3_17_2_1_1761603656792_186> 
- <a href="https://www.paypal.com/donate/?hosted_button_id=X4VGJ5VTWXVUN" class="sqs-block-button-element--medium sqs-button-element--primary sqs-block-button-element" data-sqsp-button target=_blank data-initialized=true>
+ <a href="/become-a-friend/" class="sqs-block-button-element--medium sqs-button-element--primary sqs-block-button-element" data-sqsp-button target=_blank data-initialized=true>
  Donate
  </a>
  <style class=sf-hidden>#block-yui_3_17_2_1_1729540697805_58139{--sqs-block-content-flex:0}</style>
@@ -1366,7 +1366,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
  <nav class="Index-nav overlay sf-hidden" id="mobile-nav">
  <div class="Index-nav-inner">
   <a href=. class="Index-nav-item">Home</a>
-  <a href="https://www.paypal.com/donate/?hosted_button_id=X4VGJ5VTWXVUN" class="Index-nav-item">Donate</a>
+  <a href="/become-a-friend/" class="Index-nav-item">Donate</a>
   <a href=donors class="Index-nav-item">Donors</a>
   <a href=become-a-friend class="Index-nav-item">Become a Friend</a>
   <a href=press class="Index-nav-item">Press</a>

--- a/press/index.html
+++ b/press/index.html
@@ -84,7 +84,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
  <nav class="Header-nav Header-nav--primary" data-nc-element=primary-nav data-content-field=navigation>
  
  <div class=Header-nav-inner>
- <a href=https://thecrookedhouse.net/ class=Header-nav-item data-test=template-nav>Home</a><a href="https://www.paypal.com/donate/?hosted_button_id=X4VGJ5VTWXVUN" class=Header-nav-item>Donate</a><a href=https://thecrookedhouse.net/donors class=Header-nav-item data-test=template-nav>Donors</a><a href=https://thecrookedhouse.net/become-a-friend class=Header-nav-item data-test=template-nav>Become a Friend</a><a href=https://thecrookedhouse.net/press class="Header-nav-item Header-nav-item--active" data-test=template-nav>Press</a>
+ <a href=https://thecrookedhouse.net/ class=Header-nav-item data-test=template-nav>Home</a><a href="/become-a-friend/" class=Header-nav-item>Donate</a><a href=https://thecrookedhouse.net/donors class=Header-nav-item data-test=template-nav>Donors</a><a href=https://thecrookedhouse.net/become-a-friend class=Header-nav-item data-test=template-nav>Become a Friend</a><a href=https://thecrookedhouse.net/press class="Header-nav-item Header-nav-item--active" data-test=template-nav>Press</a>
  </div>
  </nav><nav class="Header-nav Header-nav--secondary" data-nc-element=secondary-nav data-content-field=navigation>
  


### PR DESCRIPTION
## Why
The PayPal \`hosted_button_id=X4VGJ5VTWXVUN\` now returns **404 page-not-found**. Every Donate button on the site is broken. Donors clicking Donate are hitting dead links.

## What
Replace all 8 occurrences of \`https://www.paypal.com/donate/?hosted_button_id=X4VGJ5VTWXVUN\` with \`/become-a-friend/\`:
- 404.html
- index.html (3x — header nav, main CTA, Index-nav)
- donors/index.html (header nav)
- press/index.html (header nav)
- become-a-friend/index.html (header nav + main CTA — note the main CTA becomes a same-page link; iterate later if needed)

The /become-a-friend/ page has the working Email Us button. Donors reaching out can be guided to a working donation method manually until Zeffy (#71) is set up.

## Test plan
- [ ] After deploy, click Donate from /, /donors/, /press/, /become-a-friend/, /404 — none should 404
- [ ] grep -r 'X4VGJ5VTWXVUN\|paypal.com/donate' the repo returns nothing