### PR TITLE
Security hardening: wire-site add-paths + WIF tightened + incident log

### DIFF
--- a/.github/workflows/google-setup.yml
+++ b/.github/workflows/google-setup.yml
@@ -121,6 +121,13 @@ jobs:
           branch: chore/wire-gtm-snippet
           title: 'Wire GTM container snippet into pages'
           commit-message: 'Wire GTM container snippet into pages'
+          # IMPORTANT: explicit allowlist so we never commit ephemeral
+          # auth artifacts like gha-creds-*.json (which caused the
+          # 2026-05-15 secret-scanning incident — see SECURITY.md).
+          add-paths: |
+            *.html
+            **/*.html
+            cookie-consent.js
           body: |
             Automated: ran `scripts/google/wire-site.py` and patched HTML to load the GTM container `${{ vars.GTM_CONTAINER_ID }}` plus the consent-mode v2 default state.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -54,6 +54,23 @@ Each service has its own security and privacy policies. Please refer to their re
 
 This security policy may be updated periodically. Please check back regularly for any changes.
 
+## Incident log
+
+### 2026-05-15 — GitHub Actions OIDC token committed to a PR
+
+**What.** A `gha-creds-*.json` file (Workload Identity Federation credential file written by `google-github-actions/auth@v2`, containing a short-lived GitHub Actions OIDC JWT) was accidentally included in PR #94 by the wire-site step of the Google API setup workflow. GitHub Secret Scanning flagged it.
+
+**Risk.** The leaked artifact was an OIDC JWT (not a Google access token). Until the JWT expired at 2026-05-16 02:09 UTC (~6 hours from the leak), it could have been exchanged via STS for a Google access token impersonating the `githubactions-thecrookedhouse@…` service account.
+
+**Mitigations applied.**
+
+- Service account `githubactions-thecrookedhouse@charming-hour-496417-p9.iam.gserviceaccount.com` was **disabled** via `gcloud iam service-accounts disable` within ~30 minutes of detection. Disabled SAs cannot be impersonated, so any subsequent STS exchange of the leaked JWT failed.
+- `.gitignore` updated (commit `01d4acb`) to exclude `gha-creds-*.json` from any future commit.
+- The workflow's `peter-evans/create-pull-request` step now uses an explicit `add-paths` allowlist so only intended files (HTML + cookie-consent.js) are committed by automation. Eliminates the leak vector at the source.
+- The WIF provider's `attributeCondition` was tightened from `assertion.repository_owner == 'FreeForCharity'` to `assertion.repository == 'FreeForCharity/FFC-EX-thecrookedhouse.net'`. Reduces blast radius — even a leaked OIDC token from a different FreeForCharity repo cannot impersonate this SA.
+
+**No unauthorized API activity** was detected on the GTM / GA accounts during the exposure window.
+
 ---
 
-Last Updated: February 2026
+Last Updated: 2026-05-15


### PR DESCRIPTION
## Why
Following the 2026-05-15 GitHub Secret Scanning alert (\`gha-creds-*.json\` committed by PR #94's wire-site step). All immediate-response steps (SA disabled, .gitignore updated) have been taken already; this PR captures the durable changes so the next FFC site doesn't repeat the incident.

## Changes
1. **\`.github/workflows/google-setup.yml\`** — wire-site PR action now has an explicit \`add-paths\` allowlist. Only HTML files + cookie-consent.js can be committed by automation. Ephemeral auth files in the working directory (like \`gha-creds-*.json\`) are no longer in the auto-commit set.
2. **\`SECURITY.md\`** — incident log entry with what / risk / mitigations / outcome (no unauthorized activity detected).
3. **WIF provider \`attributeCondition\`** (already applied via gcloud) — tightened from \`repository_owner == 'FreeForCharity'\` to \`repository == 'FreeForCharity/FFC-EX-thecrookedhouse.net'\`. Even a leaked OIDC from another FFC repo cannot impersonate this SA.

## What's NOT in this PR
- Service account remains **disabled** until you explicitly re-enable it before the next workflow run (\`gcloud iam service-accounts enable …\`).
- GitHub Secret Scanning alert needs to be closed in the UI as "Revoked".

## Test plan
- [ ] Workflow YAML still parses (will be validated on next workflow_dispatch)
- [ ] On a future wire-site run, only \`*.html\` and \`cookie-consent.js\` appear in the auto-PR